### PR TITLE
Update to how emergency backstop works

### DIFF
--- a/bxbot-core/src/main/java/com/gazbert/bxbot/core/engine/TradingEngine.java
+++ b/bxbot-core/src/main/java/com/gazbert/bxbot/core/engine/TradingEngine.java
@@ -340,9 +340,7 @@ public class TradingEngine {
 
         boolean isEmergencyStopLimitBreached = true;
 
-        //Added by Gondee. This prevents an API Call from being wasted if the user elects not to use the emergency stop
-        //This is elected by putting 0 in the config file as the emergency stop balance
-        if(emergencyStopBalance.equals(new BigDecimal("0"))){
+        if(emergencyStopBalance.compareTo(BigDecimal.ZERO) == 0){
             return false;
         }
 

--- a/bxbot-core/src/main/java/com/gazbert/bxbot/core/engine/TradingEngine.java
+++ b/bxbot-core/src/main/java/com/gazbert/bxbot/core/engine/TradingEngine.java
@@ -340,6 +340,12 @@ public class TradingEngine {
 
         boolean isEmergencyStopLimitBreached = true;
 
+        //Added by Gondee. This prevents an API Call from being wasted if the user elects not to use the emergency stop
+        //This is elected by putting 0 in the config file as the emergency stop balance
+        if(emergencyStopBalance.equals(new BigDecimal("0"))){
+            return false;
+        }
+
         LOG.info(() -> "Performing Emergency Stop check...");
 
         BalanceInfo balanceInfo;


### PR DESCRIPTION
Currently if a bot is running with the emergency backstop set to 0 (indicating that the feature is not needed, the bot still performs an API call. In situations where a bot needs to be operating quickly, this both lowers your API calls available for the bot and slows down the bot by the RRT of the call. 