### PR TITLE
KrakenAdaptor place order with expected precision

### DIFF
--- a/bxbot-exchange-api/src/main/java/com/gazbert/bxbot/exchange/api/PairPrecisionConfig.java
+++ b/bxbot-exchange-api/src/main/java/com/gazbert/bxbot/exchange/api/PairPrecisionConfig.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Gareth Jon Lynch
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.gazbert.bxbot.exchange.api;
+
+/**
+ * <p>Some Exchange Adapters will need custom precision configs when placing orders.</p>
+ *
+ * <p>This interface allows us to have a uniform way to fetch this precision for the
+ * various Exchange houses.</p>
+ *
+ * @author maiph
+ * @since 1.2
+ */
+public interface PairPrecisionConfig {
+
+  /**
+   * Gets the number of decimal places for price precision. The default value id no pair is found
+   * will be -1.
+   *
+   * @param pair the coin pair.
+   * @return the number of decimal places for the price.
+   */
+  int getPricePrecision(String pair);
+
+  /**
+   * Gets the number of decimal places for volume precision. The default value id no pair is found
+   * will be -1.
+   *
+   * @param pair the coin pair.
+   * @return the number of decimal places for volume.
+   */
+  int getVolumePrecision(String pair);
+
+}

--- a/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/config/PairPrecisionConfigImpl.java
+++ b/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/config/PairPrecisionConfigImpl.java
@@ -1,0 +1,30 @@
+package com.gazbert.bxbot.exchanges.config;
+
+import com.gazbert.bxbot.exchange.api.PairPrecisionConfig;
+import java.util.Map;
+
+/**
+ * Default implementation of {@link PairPrecisionConfig} backed by {@link Map}s.
+ *
+ * @author maiph
+ */
+public class PairPrecisionConfigImpl implements PairPrecisionConfig {
+
+  private final Map<String, Integer> prices;
+  private final Map<String, Integer> volumes;
+
+  public PairPrecisionConfigImpl(Map<String, Integer> prices, Map<String, Integer> volumes) {
+    this.prices = prices;
+    this.volumes = volumes;
+  }
+
+  @Override
+  public int getPricePrecision(String pair) {
+    return prices.getOrDefault(pair, -1);
+  }
+
+  @Override
+  public int getVolumePrecision(String pair) {
+    return volumes.getOrDefault(pair, -1);
+  }
+}

--- a/bxbot-exchanges/src/test/exchange-data/kraken/AssetPairs.json
+++ b/bxbot-exchanges/src/test/exchange-data/kraken/AssetPairs.json
@@ -1,0 +1,24117 @@
+{
+  "error": [],
+  "result": {
+    "AAVEETH": {
+      "altname": "AAVEETH",
+      "wsname": "AAVE\/ETH",
+      "aclass_base": "currency",
+      "base": "AAVE",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "AAVEEUR": {
+      "altname": "AAVEEUR",
+      "wsname": "AAVE\/EUR",
+      "aclass_base": "currency",
+      "base": "AAVE",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "AAVEGBP": {
+      "altname": "AAVEGBP",
+      "wsname": "AAVE\/GBP",
+      "aclass_base": "currency",
+      "base": "AAVE",
+      "aclass_quote": "currency",
+      "quote": "ZGBP",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "AAVEUSD": {
+      "altname": "AAVEUSD",
+      "wsname": "AAVE\/USD",
+      "aclass_base": "currency",
+      "base": "AAVE",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "AAVEXBT": {
+      "altname": "AAVEXBT",
+      "wsname": "AAVE\/XBT",
+      "aclass_base": "currency",
+      "base": "AAVE",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "ADAETH": {
+      "altname": "ADAETH",
+      "wsname": "ADA\/ETH",
+      "aclass_base": "currency",
+      "base": "ADA",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "ADAEUR": {
+      "altname": "ADAEUR",
+      "wsname": "ADA\/EUR",
+      "aclass_base": "currency",
+      "base": "ADA",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "ADAUSD": {
+      "altname": "ADAUSD",
+      "wsname": "ADA\/USD",
+      "aclass_base": "currency",
+      "base": "ADA",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "ADAUSDT": {
+      "altname": "ADAUSDT",
+      "wsname": "ADA\/USDT",
+      "aclass_base": "currency",
+      "base": "ADA",
+      "aclass_quote": "currency",
+      "quote": "USDT",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "ADAXBT": {
+      "altname": "ADAXBT",
+      "wsname": "ADA\/XBT",
+      "aclass_base": "currency",
+      "base": "ADA",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "ALGOETH": {
+      "altname": "ALGOETH",
+      "wsname": "ALGO\/ETH",
+      "aclass_base": "currency",
+      "base": "ALGO",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "ALGOEUR": {
+      "altname": "ALGOEUR",
+      "wsname": "ALGO\/EUR",
+      "aclass_base": "currency",
+      "base": "ALGO",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "ALGOUSD": {
+      "altname": "ALGOUSD",
+      "wsname": "ALGO\/USD",
+      "aclass_base": "currency",
+      "base": "ALGO",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "ALGOXBT": {
+      "altname": "ALGOXBT",
+      "wsname": "ALGO\/XBT",
+      "aclass_base": "currency",
+      "base": "ALGO",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "ANTETH": {
+      "altname": "ANTETH",
+      "wsname": "ANT\/ETH",
+      "aclass_base": "currency",
+      "base": "ANT",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "ANTEUR": {
+      "altname": "ANTEUR",
+      "wsname": "ANT\/EUR",
+      "aclass_base": "currency",
+      "base": "ANT",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "ANTUSD": {
+      "altname": "ANTUSD",
+      "wsname": "ANT\/USD",
+      "aclass_base": "currency",
+      "base": "ANT",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "ANTXBT": {
+      "altname": "ANTXBT",
+      "wsname": "ANT\/XBT",
+      "aclass_base": "currency",
+      "base": "ANT",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "ATOMETH": {
+      "altname": "ATOMETH",
+      "wsname": "ATOM\/ETH",
+      "aclass_base": "currency",
+      "base": "ATOM",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "ATOMEUR": {
+      "altname": "ATOMEUR",
+      "wsname": "ATOM\/EUR",
+      "aclass_base": "currency",
+      "base": "ATOM",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "ATOMUSD": {
+      "altname": "ATOMUSD",
+      "wsname": "ATOM\/USD",
+      "aclass_base": "currency",
+      "base": "ATOM",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "ATOMXBT": {
+      "altname": "ATOMXBT",
+      "wsname": "ATOM\/XBT",
+      "aclass_base": "currency",
+      "base": "ATOM",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "AUDJPY": {
+      "altname": "AUDJPY",
+      "wsname": "AUD\/JPY",
+      "aclass_base": "currency",
+      "base": "ZAUD",
+      "aclass_quote": "currency",
+      "quote": "ZJPY",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "AUDUSD": {
+      "altname": "AUDUSD",
+      "wsname": "AUD\/USD",
+      "aclass_base": "currency",
+      "base": "ZAUD",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "BALETH": {
+      "altname": "BALETH",
+      "wsname": "BAL\/ETH",
+      "aclass_base": "currency",
+      "base": "BAL",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "BALEUR": {
+      "altname": "BALEUR",
+      "wsname": "BAL\/EUR",
+      "aclass_base": "currency",
+      "base": "BAL",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "BALUSD": {
+      "altname": "BALUSD",
+      "wsname": "BAL\/USD",
+      "aclass_base": "currency",
+      "base": "BAL",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "BALXBT": {
+      "altname": "BALXBT",
+      "wsname": "BAL\/XBT",
+      "aclass_base": "currency",
+      "base": "BAL",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "BATETH": {
+      "altname": "BATETH",
+      "wsname": "BAT\/ETH",
+      "aclass_base": "currency",
+      "base": "BAT",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "BATEUR": {
+      "altname": "BATEUR",
+      "wsname": "BAT\/EUR",
+      "aclass_base": "currency",
+      "base": "BAT",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "BATUSD": {
+      "altname": "BATUSD",
+      "wsname": "BAT\/USD",
+      "aclass_base": "currency",
+      "base": "BAT",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "BATXBT": {
+      "altname": "BATXBT",
+      "wsname": "BAT\/XBT",
+      "aclass_base": "currency",
+      "base": "BAT",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "BCHAUD": {
+      "altname": "BCHAUD",
+      "wsname": "BCH\/AUD",
+      "aclass_base": "currency",
+      "base": "BCH",
+      "aclass_quote": "currency",
+      "quote": "ZAUD",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.025"
+    },
+    "BCHETH": {
+      "altname": "BCHETH",
+      "wsname": "BCH\/ETH",
+      "aclass_base": "currency",
+      "base": "BCH",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.025"
+    },
+    "BCHEUR": {
+      "altname": "BCHEUR",
+      "wsname": "BCH\/EUR",
+      "aclass_base": "currency",
+      "base": "BCH",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.025"
+    },
+    "BCHGBP": {
+      "altname": "BCHGBP",
+      "wsname": "BCH\/GBP",
+      "aclass_base": "currency",
+      "base": "BCH",
+      "aclass_quote": "currency",
+      "quote": "ZGBP",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.025"
+    },
+    "BCHJPY": {
+      "altname": "BCHJPY",
+      "wsname": "BCH\/JPY",
+      "aclass_base": "currency",
+      "base": "BCH",
+      "aclass_quote": "currency",
+      "quote": "ZJPY",
+      "lot": "unit",
+      "pair_decimals": 0,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.025"
+    },
+    "BCHUSD": {
+      "altname": "BCHUSD",
+      "wsname": "BCH\/USD",
+      "aclass_base": "currency",
+      "base": "BCH",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.025"
+    },
+    "BCHUSDT": {
+      "altname": "BCHUSDT",
+      "wsname": "BCH\/USDT",
+      "aclass_base": "currency",
+      "base": "BCH",
+      "aclass_quote": "currency",
+      "quote": "USDT",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.025"
+    },
+    "BCHXBT": {
+      "altname": "BCHXBT",
+      "wsname": "BCH\/XBT",
+      "aclass_base": "currency",
+      "base": "BCH",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.025"
+    },
+    "COMPETH": {
+      "altname": "COMPETH",
+      "wsname": "COMP\/ETH",
+      "aclass_base": "currency",
+      "base": "COMP",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.025"
+    },
+    "COMPEUR": {
+      "altname": "COMPEUR",
+      "wsname": "COMP\/EUR",
+      "aclass_base": "currency",
+      "base": "COMP",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.025"
+    },
+    "COMPUSD": {
+      "altname": "COMPUSD",
+      "wsname": "COMP\/USD",
+      "aclass_base": "currency",
+      "base": "COMP",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.025"
+    },
+    "COMPXBT": {
+      "altname": "COMPXBT",
+      "wsname": "COMP\/XBT",
+      "aclass_base": "currency",
+      "base": "COMP",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.025"
+    },
+    "CRVETH": {
+      "altname": "CRVETH",
+      "wsname": "CRV\/ETH",
+      "aclass_base": "currency",
+      "base": "CRV",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "CRVEUR": {
+      "altname": "CRVEUR",
+      "wsname": "CRV\/EUR",
+      "aclass_base": "currency",
+      "base": "CRV",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "CRVUSD": {
+      "altname": "CRVUSD",
+      "wsname": "CRV\/USD",
+      "aclass_base": "currency",
+      "base": "CRV",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "CRVXBT": {
+      "altname": "CRVXBT",
+      "wsname": "CRV\/XBT",
+      "aclass_base": "currency",
+      "base": "CRV",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "DAIEUR": {
+      "altname": "DAIEUR",
+      "wsname": "DAI\/EUR",
+      "aclass_base": "currency",
+      "base": "DAI",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "DAIUSD": {
+      "altname": "DAIUSD",
+      "wsname": "DAI\/USD",
+      "aclass_base": "currency",
+      "base": "DAI",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "DAIUSDT": {
+      "altname": "DAIUSDT",
+      "wsname": "DAI\/USDT",
+      "aclass_base": "currency",
+      "base": "DAI",
+      "aclass_quote": "currency",
+      "quote": "USDT",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "DASHEUR": {
+      "altname": "DASHEUR",
+      "wsname": "DASH\/EUR",
+      "aclass_base": "currency",
+      "base": "DASH",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.03"
+    },
+    "DASHUSD": {
+      "altname": "DASHUSD",
+      "wsname": "DASH\/USD",
+      "aclass_base": "currency",
+      "base": "DASH",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.03"
+    },
+    "DASHXBT": {
+      "altname": "DASHXBT",
+      "wsname": "DASH\/XBT",
+      "aclass_base": "currency",
+      "base": "DASH",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.03"
+    },
+    "DOTETH": {
+      "altname": "DOTETH",
+      "wsname": "DOT\/ETH",
+      "aclass_base": "currency",
+      "base": "DOT",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "DOTEUR": {
+      "altname": "DOTEUR",
+      "wsname": "DOT\/EUR",
+      "aclass_base": "currency",
+      "base": "DOT",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "DOTUSD": {
+      "altname": "DOTUSD",
+      "wsname": "DOT\/USD",
+      "aclass_base": "currency",
+      "base": "DOT",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "DOTUSDT": {
+      "altname": "DOTUSDT",
+      "wsname": "DOT\/USDT",
+      "aclass_base": "currency",
+      "base": "DOT",
+      "aclass_quote": "currency",
+      "quote": "USDT",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "DOTXBT": {
+      "altname": "DOTXBT",
+      "wsname": "DOT\/XBT",
+      "aclass_base": "currency",
+      "base": "DOT",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "EOSETH": {
+      "altname": "EOSETH",
+      "wsname": "EOS\/ETH",
+      "aclass_base": "currency",
+      "base": "EOS",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "3"
+    },
+    "EOSEUR": {
+      "altname": "EOSEUR",
+      "wsname": "EOS\/EUR",
+      "aclass_base": "currency",
+      "base": "EOS",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "3"
+    },
+    "EOSUSD": {
+      "altname": "EOSUSD",
+      "wsname": "EOS\/USD",
+      "aclass_base": "currency",
+      "base": "EOS",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "3"
+    },
+    "EOSUSDT": {
+      "altname": "EOSUSDT",
+      "wsname": "EOS\/USDT",
+      "aclass_base": "currency",
+      "base": "EOS",
+      "aclass_quote": "currency",
+      "quote": "USDT",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "3"
+    },
+    "EOSXBT": {
+      "altname": "EOSXBT",
+      "wsname": "EOS\/XBT",
+      "aclass_base": "currency",
+      "base": "EOS",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "3"
+    },
+    "ETH2.SETH": {
+      "altname": "ETH2.SETH",
+      "wsname": "ETH2.S\/ETH",
+      "aclass_base": "currency",
+      "base": "ETH2.S",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.02"
+    },
+    "ETHAUD": {
+      "altname": "ETHAUD",
+      "wsname": "ETH\/AUD",
+      "aclass_base": "currency",
+      "base": "XETH",
+      "aclass_quote": "currency",
+      "quote": "ZAUD",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.02"
+    },
+    "ETHCHF": {
+      "altname": "ETHCHF",
+      "wsname": "ETH\/CHF",
+      "aclass_base": "currency",
+      "base": "XETH",
+      "aclass_quote": "currency",
+      "quote": "CHF",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.02"
+    },
+    "ETHDAI": {
+      "altname": "ETHDAI",
+      "wsname": "ETH\/DAI",
+      "aclass_base": "currency",
+      "base": "XETH",
+      "aclass_quote": "currency",
+      "quote": "DAI",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.02"
+    },
+    "ETHUSDC": {
+      "altname": "ETHUSDC",
+      "wsname": "ETH\/USDC",
+      "aclass_base": "currency",
+      "base": "XETH",
+      "aclass_quote": "currency",
+      "quote": "USDC",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.02"
+    },
+    "ETHUSDT": {
+      "altname": "ETHUSDT",
+      "wsname": "ETH\/USDT",
+      "aclass_base": "currency",
+      "base": "XETH",
+      "aclass_quote": "currency",
+      "quote": "USDT",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.02"
+    },
+    "EURAUD": {
+      "altname": "EURAUD",
+      "wsname": "EUR\/AUD",
+      "aclass_base": "currency",
+      "base": "ZEUR",
+      "aclass_quote": "currency",
+      "quote": "ZAUD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "EURCAD": {
+      "altname": "EURCAD",
+      "wsname": "EUR\/CAD",
+      "aclass_base": "currency",
+      "base": "ZEUR",
+      "aclass_quote": "currency",
+      "quote": "ZCAD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "EURCHF": {
+      "altname": "EURCHF",
+      "wsname": "EUR\/CHF",
+      "aclass_base": "currency",
+      "base": "ZEUR",
+      "aclass_quote": "currency",
+      "quote": "CHF",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "EURGBP": {
+      "altname": "EURGBP",
+      "wsname": "EUR\/GBP",
+      "aclass_base": "currency",
+      "base": "ZEUR",
+      "aclass_quote": "currency",
+      "quote": "ZGBP",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "EURJPY": {
+      "altname": "EURJPY",
+      "wsname": "EUR\/JPY",
+      "aclass_base": "currency",
+      "base": "ZEUR",
+      "aclass_quote": "currency",
+      "quote": "ZJPY",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "FILETH": {
+      "altname": "FILETH",
+      "wsname": "FIL\/ETH",
+      "aclass_base": "currency",
+      "base": "FIL",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.125"
+    },
+    "FILEUR": {
+      "altname": "FILEUR",
+      "wsname": "FIL\/EUR",
+      "aclass_base": "currency",
+      "base": "FIL",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.125"
+    },
+    "FILUSD": {
+      "altname": "FILUSD",
+      "wsname": "FIL\/USD",
+      "aclass_base": "currency",
+      "base": "FIL",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.125"
+    },
+    "FILXBT": {
+      "altname": "FILXBT",
+      "wsname": "FIL\/XBT",
+      "aclass_base": "currency",
+      "base": "FIL",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.125"
+    },
+    "GNOETH": {
+      "altname": "GNOETH",
+      "wsname": "GNO\/ETH",
+      "aclass_base": "currency",
+      "base": "GNO",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.02"
+    },
+    "GNOEUR": {
+      "altname": "GNOEUR",
+      "wsname": "GNO\/EUR",
+      "aclass_base": "currency",
+      "base": "GNO",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.02"
+    },
+    "GNOUSD": {
+      "altname": "GNOUSD",
+      "wsname": "GNO\/USD",
+      "aclass_base": "currency",
+      "base": "GNO",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.02"
+    },
+    "GNOXBT": {
+      "altname": "GNOXBT",
+      "wsname": "GNO\/XBT",
+      "aclass_base": "currency",
+      "base": "GNO",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.02"
+    },
+    "GRTETH": {
+      "altname": "GRTETH",
+      "wsname": "GRT\/ETH",
+      "aclass_base": "currency",
+      "base": "GRT",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "GRTEUR": {
+      "altname": "GRTEUR",
+      "wsname": "GRT\/EUR",
+      "aclass_base": "currency",
+      "base": "GRT",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "GRTUSD": {
+      "altname": "GRTUSD",
+      "wsname": "GRT\/USD",
+      "aclass_base": "currency",
+      "base": "GRT",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "GRTXBT": {
+      "altname": "GRTXBT",
+      "wsname": "GRT\/XBT",
+      "aclass_base": "currency",
+      "base": "GRT",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "ICXETH": {
+      "altname": "ICXETH",
+      "wsname": "ICX\/ETH",
+      "aclass_base": "currency",
+      "base": "ICX",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "20"
+    },
+    "ICXEUR": {
+      "altname": "ICXEUR",
+      "wsname": "ICX\/EUR",
+      "aclass_base": "currency",
+      "base": "ICX",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "20"
+    },
+    "ICXUSD": {
+      "altname": "ICXUSD",
+      "wsname": "ICX\/USD",
+      "aclass_base": "currency",
+      "base": "ICX",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "20"
+    },
+    "ICXXBT": {
+      "altname": "ICXXBT",
+      "wsname": "ICX\/XBT",
+      "aclass_base": "currency",
+      "base": "ICX",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "20"
+    },
+    "KAVAETH": {
+      "altname": "KAVAETH",
+      "wsname": "KAVA\/ETH",
+      "aclass_base": "currency",
+      "base": "KAVA",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "KAVAEUR": {
+      "altname": "KAVAEUR",
+      "wsname": "KAVA\/EUR",
+      "aclass_base": "currency",
+      "base": "KAVA",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "KAVAUSD": {
+      "altname": "KAVAUSD",
+      "wsname": "KAVA\/USD",
+      "aclass_base": "currency",
+      "base": "KAVA",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "KAVAXBT": {
+      "altname": "KAVAXBT",
+      "wsname": "KAVA\/XBT",
+      "aclass_base": "currency",
+      "base": "KAVA",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "KEEPETH": {
+      "altname": "KEEPETH",
+      "wsname": "KEEP\/ETH",
+      "aclass_base": "currency",
+      "base": "KEEP",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "KEEPEUR": {
+      "altname": "KEEPEUR",
+      "wsname": "KEEP\/EUR",
+      "aclass_base": "currency",
+      "base": "KEEP",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "KEEPUSD": {
+      "altname": "KEEPUSD",
+      "wsname": "KEEP\/USD",
+      "aclass_base": "currency",
+      "base": "KEEP",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "KEEPXBT": {
+      "altname": "KEEPXBT",
+      "wsname": "KEEP\/XBT",
+      "aclass_base": "currency",
+      "base": "KEEP",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "KNCETH": {
+      "altname": "KNCETH",
+      "wsname": "KNC\/ETH",
+      "aclass_base": "currency",
+      "base": "KNC",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "KNCEUR": {
+      "altname": "KNCEUR",
+      "wsname": "KNC\/EUR",
+      "aclass_base": "currency",
+      "base": "KNC",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "KNCUSD": {
+      "altname": "KNCUSD",
+      "wsname": "KNC\/USD",
+      "aclass_base": "currency",
+      "base": "KNC",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "KNCXBT": {
+      "altname": "KNCXBT",
+      "wsname": "KNC\/XBT",
+      "aclass_base": "currency",
+      "base": "KNC",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "KSMETH": {
+      "altname": "KSMETH",
+      "wsname": "KSM\/ETH",
+      "aclass_base": "currency",
+      "base": "KSM",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "KSMEUR": {
+      "altname": "KSMEUR",
+      "wsname": "KSM\/EUR",
+      "aclass_base": "currency",
+      "base": "KSM",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "KSMUSD": {
+      "altname": "KSMUSD",
+      "wsname": "KSM\/USD",
+      "aclass_base": "currency",
+      "base": "KSM",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "KSMXBT": {
+      "altname": "KSMXBT",
+      "wsname": "KSM\/XBT",
+      "aclass_base": "currency",
+      "base": "KSM",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "LINKETH": {
+      "altname": "LINKETH",
+      "wsname": "LINK\/ETH",
+      "aclass_base": "currency",
+      "base": "LINK",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "2"
+    },
+    "LINKEUR": {
+      "altname": "LINKEUR",
+      "wsname": "LINK\/EUR",
+      "aclass_base": "currency",
+      "base": "LINK",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "2"
+    },
+    "LINKUSD": {
+      "altname": "LINKUSD",
+      "wsname": "LINK\/USD",
+      "aclass_base": "currency",
+      "base": "LINK",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "2"
+    },
+    "LINKUSDT": {
+      "altname": "LINKUSDT",
+      "wsname": "LINK\/USDT",
+      "aclass_base": "currency",
+      "base": "LINK",
+      "aclass_quote": "currency",
+      "quote": "USDT",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "2"
+    },
+    "LINKXBT": {
+      "altname": "LINKXBT",
+      "wsname": "LINK\/XBT",
+      "aclass_base": "currency",
+      "base": "LINK",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "2"
+    },
+    "LSKETH": {
+      "altname": "LSKETH",
+      "wsname": "LSK\/ETH",
+      "aclass_base": "currency",
+      "base": "LSK",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "LSKEUR": {
+      "altname": "LSKEUR",
+      "wsname": "LSK\/EUR",
+      "aclass_base": "currency",
+      "base": "LSK",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "LSKUSD": {
+      "altname": "LSKUSD",
+      "wsname": "LSK\/USD",
+      "aclass_base": "currency",
+      "base": "LSK",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "LSKXBT": {
+      "altname": "LSKXBT",
+      "wsname": "LSK\/XBT",
+      "aclass_base": "currency",
+      "base": "LSK",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 9,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "LTCAUD": {
+      "altname": "LTCAUD",
+      "wsname": "LTC\/AUD",
+      "aclass_base": "currency",
+      "base": "XLTC",
+      "aclass_quote": "currency",
+      "quote": "ZAUD",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "LTCETH": {
+      "altname": "LTCETH",
+      "wsname": "LTC\/ETH",
+      "aclass_base": "currency",
+      "base": "XLTC",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "LTCGBP": {
+      "altname": "LTCGBP",
+      "wsname": "LTC\/GBP",
+      "aclass_base": "currency",
+      "base": "XLTC",
+      "aclass_quote": "currency",
+      "quote": "ZGBP",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "LTCUSDT": {
+      "altname": "LTCUSDT",
+      "wsname": "LTC\/USDT",
+      "aclass_base": "currency",
+      "base": "XLTC",
+      "aclass_quote": "currency",
+      "quote": "USDT",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "MANAETH": {
+      "altname": "MANAETH",
+      "wsname": "MANA\/ETH",
+      "aclass_base": "currency",
+      "base": "MANA",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "MANAEUR": {
+      "altname": "MANAEUR",
+      "wsname": "MANA\/EUR",
+      "aclass_base": "currency",
+      "base": "MANA",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "MANAUSD": {
+      "altname": "MANAUSD",
+      "wsname": "MANA\/USD",
+      "aclass_base": "currency",
+      "base": "MANA",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "MANAXBT": {
+      "altname": "MANAXBT",
+      "wsname": "MANA\/XBT",
+      "aclass_base": "currency",
+      "base": "MANA",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "NANOETH": {
+      "altname": "NANOETH",
+      "wsname": "NANO\/ETH",
+      "aclass_base": "currency",
+      "base": "NANO",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "NANOEUR": {
+      "altname": "NANOEUR",
+      "wsname": "NANO\/EUR",
+      "aclass_base": "currency",
+      "base": "NANO",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "NANOUSD": {
+      "altname": "NANOUSD",
+      "wsname": "NANO\/USD",
+      "aclass_base": "currency",
+      "base": "NANO",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "NANOXBT": {
+      "altname": "NANOXBT",
+      "wsname": "NANO\/XBT",
+      "aclass_base": "currency",
+      "base": "NANO",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 9,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "OMGETH": {
+      "altname": "OMGETH",
+      "wsname": "OMG\/ETH",
+      "aclass_base": "currency",
+      "base": "OMG",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "5"
+    },
+    "OMGEUR": {
+      "altname": "OMGEUR",
+      "wsname": "OMG\/EUR",
+      "aclass_base": "currency",
+      "base": "OMG",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "5"
+    },
+    "OMGUSD": {
+      "altname": "OMGUSD",
+      "wsname": "OMG\/USD",
+      "aclass_base": "currency",
+      "base": "OMG",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "5"
+    },
+    "OMGXBT": {
+      "altname": "OMGXBT",
+      "wsname": "OMG\/XBT",
+      "aclass_base": "currency",
+      "base": "OMG",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 9,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "5"
+    },
+    "OXTETH": {
+      "altname": "OXTETH",
+      "wsname": "OXT\/ETH",
+      "aclass_base": "currency",
+      "base": "OXT",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "OXTEUR": {
+      "altname": "OXTEUR",
+      "wsname": "OXT\/EUR",
+      "aclass_base": "currency",
+      "base": "OXT",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "OXTUSD": {
+      "altname": "OXTUSD",
+      "wsname": "OXT\/USD",
+      "aclass_base": "currency",
+      "base": "OXT",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "OXTXBT": {
+      "altname": "OXTXBT",
+      "wsname": "OXT\/XBT",
+      "aclass_base": "currency",
+      "base": "OXT",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "PAXGETH": {
+      "altname": "PAXGETH",
+      "wsname": "PAXG\/ETH",
+      "aclass_base": "currency",
+      "base": "PAXG",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.005"
+    },
+    "PAXGEUR": {
+      "altname": "PAXGEUR",
+      "wsname": "PAXG\/EUR",
+      "aclass_base": "currency",
+      "base": "PAXG",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.005"
+    },
+    "PAXGUSD": {
+      "altname": "PAXGUSD",
+      "wsname": "PAXG\/USD",
+      "aclass_base": "currency",
+      "base": "PAXG",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.005"
+    },
+    "PAXGXBT": {
+      "altname": "PAXGXBT",
+      "wsname": "PAXG\/XBT",
+      "aclass_base": "currency",
+      "base": "PAXG",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.005"
+    },
+    "QTUMETH": {
+      "altname": "QTUMETH",
+      "wsname": "QTUM\/ETH",
+      "aclass_base": "currency",
+      "base": "QTUM",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "5"
+    },
+    "QTUMEUR": {
+      "altname": "QTUMEUR",
+      "wsname": "QTUM\/EUR",
+      "aclass_base": "currency",
+      "base": "QTUM",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "5"
+    },
+    "QTUMUSD": {
+      "altname": "QTUMUSD",
+      "wsname": "QTUM\/USD",
+      "aclass_base": "currency",
+      "base": "QTUM",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "5"
+    },
+    "QTUMXBT": {
+      "altname": "QTUMXBT",
+      "wsname": "QTUM\/XBT",
+      "aclass_base": "currency",
+      "base": "QTUM",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "5"
+    },
+    "REPV2ETH": {
+      "altname": "REPV2ETH",
+      "wsname": "REPV2\/ETH",
+      "aclass_base": "currency",
+      "base": "REPV2",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.3"
+    },
+    "REPV2EUR": {
+      "altname": "REPV2EUR",
+      "wsname": "REPV2\/EUR",
+      "aclass_base": "currency",
+      "base": "REPV2",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.3"
+    },
+    "REPV2USD": {
+      "altname": "REPV2USD",
+      "wsname": "REPV2\/USD",
+      "aclass_base": "currency",
+      "base": "REPV2",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.3"
+    },
+    "REPV2XBT": {
+      "altname": "REPV2XBT",
+      "wsname": "REPV2\/XBT",
+      "aclass_base": "currency",
+      "base": "REPV2",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.3"
+    },
+    "SCETH": {
+      "altname": "SCETH",
+      "wsname": "SC\/ETH",
+      "aclass_base": "currency",
+      "base": "SC",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "2000"
+    },
+    "SCEUR": {
+      "altname": "SCEUR",
+      "wsname": "SC\/EUR",
+      "aclass_base": "currency",
+      "base": "SC",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "2000"
+    },
+    "SCUSD": {
+      "altname": "SCUSD",
+      "wsname": "SC\/USD",
+      "aclass_base": "currency",
+      "base": "SC",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "2000"
+    },
+    "SCXBT": {
+      "altname": "SCXBT",
+      "wsname": "SC\/XBT",
+      "aclass_base": "currency",
+      "base": "SC",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 10,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "2000"
+    },
+    "SNXETH": {
+      "altname": "SNXETH",
+      "wsname": "SNX\/ETH",
+      "aclass_base": "currency",
+      "base": "SNX",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "SNXEUR": {
+      "altname": "SNXEUR",
+      "wsname": "SNX\/EUR",
+      "aclass_base": "currency",
+      "base": "SNX",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "SNXUSD": {
+      "altname": "SNXUSD",
+      "wsname": "SNX\/USD",
+      "aclass_base": "currency",
+      "base": "SNX",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "SNXXBT": {
+      "altname": "SNXXBT",
+      "wsname": "SNX\/XBT",
+      "aclass_base": "currency",
+      "base": "SNX",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "STORJETH": {
+      "altname": "STORJETH",
+      "wsname": "STORJ\/ETH",
+      "aclass_base": "currency",
+      "base": "STORJ",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "STORJEUR": {
+      "altname": "STORJEUR",
+      "wsname": "STORJ\/EUR",
+      "aclass_base": "currency",
+      "base": "STORJ",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "STORJUSD": {
+      "altname": "STORJUSD",
+      "wsname": "STORJ\/USD",
+      "aclass_base": "currency",
+      "base": "STORJ",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "STORJXBT": {
+      "altname": "STORJXBT",
+      "wsname": "STORJ\/XBT",
+      "aclass_base": "currency",
+      "base": "STORJ",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 9,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "50"
+    },
+    "TBTCETH": {
+      "altname": "TBTCETH",
+      "wsname": "TBTC\/ETH",
+      "aclass_base": "currency",
+      "base": "TBTC",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.001"
+    },
+    "TBTCEUR": {
+      "altname": "TBTCEUR",
+      "wsname": "TBTC\/EUR",
+      "aclass_base": "currency",
+      "base": "TBTC",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 1,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.001"
+    },
+    "TBTCUSD": {
+      "altname": "TBTCUSD",
+      "wsname": "TBTC\/USD",
+      "aclass_base": "currency",
+      "base": "TBTC",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 1,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.001"
+    },
+    "TBTCXBT": {
+      "altname": "TBTCXBT",
+      "wsname": "TBTC\/XBT",
+      "aclass_base": "currency",
+      "base": "TBTC",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.001"
+    },
+    "TRXETH": {
+      "altname": "TRXETH",
+      "wsname": "TRX\/ETH",
+      "aclass_base": "currency",
+      "base": "TRX",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "500"
+    },
+    "TRXEUR": {
+      "altname": "TRXEUR",
+      "wsname": "TRX\/EUR",
+      "aclass_base": "currency",
+      "base": "TRX",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "500"
+    },
+    "TRXUSD": {
+      "altname": "TRXUSD",
+      "wsname": "TRX\/USD",
+      "aclass_base": "currency",
+      "base": "TRX",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "500"
+    },
+    "TRXXBT": {
+      "altname": "TRXXBT",
+      "wsname": "TRX\/XBT",
+      "aclass_base": "currency",
+      "base": "TRX",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 10,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "500"
+    },
+    "UNIETH": {
+      "altname": "UNIETH",
+      "wsname": "UNI\/ETH",
+      "aclass_base": "currency",
+      "base": "UNI",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.25"
+    },
+    "UNIEUR": {
+      "altname": "UNIEUR",
+      "wsname": "UNI\/EUR",
+      "aclass_base": "currency",
+      "base": "UNI",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.25"
+    },
+    "UNIUSD": {
+      "altname": "UNIUSD",
+      "wsname": "UNI\/USD",
+      "aclass_base": "currency",
+      "base": "UNI",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.25"
+    },
+    "UNIXBT": {
+      "altname": "UNIXBT",
+      "wsname": "UNI\/XBT",
+      "aclass_base": "currency",
+      "base": "UNI",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.25"
+    },
+    "USDCEUR": {
+      "altname": "USDCEUR",
+      "wsname": "USDC\/EUR",
+      "aclass_base": "currency",
+      "base": "USDC",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "5"
+    },
+    "USDCHF": {
+      "altname": "USDCHF",
+      "wsname": "USD\/CHF",
+      "aclass_base": "currency",
+      "base": "ZUSD",
+      "aclass_quote": "currency",
+      "quote": "CHF",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "USDCUSD": {
+      "altname": "USDCUSD",
+      "wsname": "USDC\/USD",
+      "aclass_base": "currency",
+      "base": "USDC",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "5"
+    },
+    "USDCUSDT": {
+      "altname": "USDCUSDT",
+      "wsname": "USDC\/USDT",
+      "aclass_base": "currency",
+      "base": "USDC",
+      "aclass_quote": "currency",
+      "quote": "USDT",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "5"
+    },
+    "USDTAUD": {
+      "altname": "USDTAUD",
+      "wsname": "USDT\/AUD",
+      "aclass_base": "currency",
+      "base": "USDT",
+      "aclass_quote": "currency",
+      "quote": "ZAUD",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "5"
+    },
+    "USDTCAD": {
+      "altname": "USDTCAD",
+      "wsname": "USDT\/CAD",
+      "aclass_base": "currency",
+      "base": "USDT",
+      "aclass_quote": "currency",
+      "quote": "ZCAD",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "5"
+    },
+    "USDTCHF": {
+      "altname": "USDTCHF",
+      "wsname": "USDT\/CHF",
+      "aclass_base": "currency",
+      "base": "USDT",
+      "aclass_quote": "currency",
+      "quote": "CHF",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "5"
+    },
+    "USDTEUR": {
+      "altname": "USDTEUR",
+      "wsname": "USDT\/EUR",
+      "aclass_base": "currency",
+      "base": "USDT",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "5"
+    },
+    "USDTGBP": {
+      "altname": "USDTGBP",
+      "wsname": "USDT\/GBP",
+      "aclass_base": "currency",
+      "base": "USDT",
+      "aclass_quote": "currency",
+      "quote": "ZGBP",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "5"
+    },
+    "USDTJPY": {
+      "altname": "USDTJPY",
+      "wsname": "USDT\/JPY",
+      "aclass_base": "currency",
+      "base": "USDT",
+      "aclass_quote": "currency",
+      "quote": "ZJPY",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "5"
+    },
+    "USDTZUSD": {
+      "altname": "USDTUSD",
+      "wsname": "USDT\/USD",
+      "aclass_base": "currency",
+      "base": "USDT",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "5"
+    },
+    "WAVESETH": {
+      "altname": "WAVESETH",
+      "wsname": "WAVES\/ETH",
+      "aclass_base": "currency",
+      "base": "WAVES",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "WAVESEUR": {
+      "altname": "WAVESEUR",
+      "wsname": "WAVES\/EUR",
+      "aclass_base": "currency",
+      "base": "WAVES",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "WAVESUSD": {
+      "altname": "WAVESUSD",
+      "wsname": "WAVES\/USD",
+      "aclass_base": "currency",
+      "base": "WAVES",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "WAVESXBT": {
+      "altname": "WAVESXBT",
+      "wsname": "WAVES\/XBT",
+      "aclass_base": "currency",
+      "base": "WAVES",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "XBTAUD": {
+      "altname": "XBTAUD",
+      "wsname": "XBT\/AUD",
+      "aclass_base": "currency",
+      "base": "XXBT",
+      "aclass_quote": "currency",
+      "quote": "ZAUD",
+      "lot": "unit",
+      "pair_decimals": 1,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.001"
+    },
+    "XBTCHF": {
+      "altname": "XBTCHF",
+      "wsname": "XBT\/CHF",
+      "aclass_base": "currency",
+      "base": "XXBT",
+      "aclass_quote": "currency",
+      "quote": "CHF",
+      "lot": "unit",
+      "pair_decimals": 1,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.001"
+    },
+    "XBTDAI": {
+      "altname": "XBTDAI",
+      "wsname": "XBT\/DAI",
+      "aclass_base": "currency",
+      "base": "XXBT",
+      "aclass_quote": "currency",
+      "quote": "DAI",
+      "lot": "unit",
+      "pair_decimals": 1,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.001"
+    },
+    "XBTUSDC": {
+      "altname": "XBTUSDC",
+      "wsname": "XBT\/USDC",
+      "aclass_base": "currency",
+      "base": "XXBT",
+      "aclass_quote": "currency",
+      "quote": "USDC",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.001"
+    },
+    "XBTUSDT": {
+      "altname": "XBTUSDT",
+      "wsname": "XBT\/USDT",
+      "aclass_base": "currency",
+      "base": "XXBT",
+      "aclass_quote": "currency",
+      "quote": "USDT",
+      "lot": "unit",
+      "pair_decimals": 1,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.001"
+    },
+    "XDGEUR": {
+      "altname": "XDGEUR",
+      "wsname": "XDG\/EUR",
+      "aclass_base": "currency",
+      "base": "XXDG",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "3000"
+    },
+    "XDGUSD": {
+      "altname": "XDGUSD",
+      "wsname": "XDG\/USD",
+      "aclass_base": "currency",
+      "base": "XXDG",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "3000"
+    },
+    "XETCXETH": {
+      "altname": "ETCETH",
+      "wsname": "ETC\/ETH",
+      "aclass_base": "currency",
+      "base": "XETC",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.3"
+    },
+    "XETCXXBT": {
+      "altname": "ETCXBT",
+      "wsname": "ETC\/XBT",
+      "aclass_base": "currency",
+      "base": "XETC",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.3"
+    },
+    "XETCZEUR": {
+      "altname": "ETCEUR",
+      "wsname": "ETC\/EUR",
+      "aclass_base": "currency",
+      "base": "XETC",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.3"
+    },
+    "XETCZUSD": {
+      "altname": "ETCUSD",
+      "wsname": "ETC\/USD",
+      "aclass_base": "currency",
+      "base": "XETC",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.3"
+    },
+    "XETHXXBT": {
+      "altname": "ETHXBT",
+      "wsname": "ETH\/XBT",
+      "aclass_base": "currency",
+      "base": "XETH",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "leverage_sell": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.02"
+    },
+    "XETHXXBT.d": {
+      "altname": "ETHXBT.d",
+      "aclass_base": "currency",
+      "base": "XETH",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.36
+        ],
+        [
+          50000,
+          0.34
+        ],
+        [
+          100000,
+          0.32
+        ],
+        [
+          250000,
+          0.3
+        ],
+        [
+          500000,
+          0.28
+        ],
+        [
+          1000000,
+          0.26
+        ],
+        [
+          2500000,
+          0.24
+        ],
+        [
+          5000000,
+          0.22
+        ],
+        [
+          10000000,
+          0.2
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40
+    },
+    "XETHZCAD": {
+      "altname": "ETHCAD",
+      "wsname": "ETH\/CAD",
+      "aclass_base": "currency",
+      "base": "XETH",
+      "aclass_quote": "currency",
+      "quote": "ZCAD",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.02"
+    },
+    "XETHZCAD.d": {
+      "altname": "ETHCAD.d",
+      "aclass_base": "currency",
+      "base": "XETH",
+      "aclass_quote": "currency",
+      "quote": "ZCAD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.36
+        ],
+        [
+          50000,
+          0.34
+        ],
+        [
+          100000,
+          0.32
+        ],
+        [
+          250000,
+          0.3
+        ],
+        [
+          500000,
+          0.28
+        ],
+        [
+          1000000,
+          0.26
+        ],
+        [
+          2500000,
+          0.24
+        ],
+        [
+          5000000,
+          0.22
+        ],
+        [
+          10000000,
+          0.2
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40
+    },
+    "XETHZEUR": {
+      "altname": "ETHEUR",
+      "wsname": "ETH\/EUR",
+      "aclass_base": "currency",
+      "base": "XETH",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "leverage_sell": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.02"
+    },
+    "XETHZEUR.d": {
+      "altname": "ETHEUR.d",
+      "aclass_base": "currency",
+      "base": "XETH",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.36
+        ],
+        [
+          50000,
+          0.34
+        ],
+        [
+          100000,
+          0.32
+        ],
+        [
+          250000,
+          0.3
+        ],
+        [
+          500000,
+          0.28
+        ],
+        [
+          1000000,
+          0.26
+        ],
+        [
+          2500000,
+          0.24
+        ],
+        [
+          5000000,
+          0.22
+        ],
+        [
+          10000000,
+          0.2
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40
+    },
+    "XETHZGBP": {
+      "altname": "ETHGBP",
+      "wsname": "ETH\/GBP",
+      "aclass_base": "currency",
+      "base": "XETH",
+      "aclass_quote": "currency",
+      "quote": "ZGBP",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.02"
+    },
+    "XETHZGBP.d": {
+      "altname": "ETHGBP.d",
+      "aclass_base": "currency",
+      "base": "XETH",
+      "aclass_quote": "currency",
+      "quote": "ZGBP",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.36
+        ],
+        [
+          50000,
+          0.34
+        ],
+        [
+          100000,
+          0.32
+        ],
+        [
+          250000,
+          0.3
+        ],
+        [
+          500000,
+          0.28
+        ],
+        [
+          1000000,
+          0.26
+        ],
+        [
+          2500000,
+          0.24
+        ],
+        [
+          5000000,
+          0.22
+        ],
+        [
+          10000000,
+          0.2
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40
+    },
+    "XETHZJPY": {
+      "altname": "ETHJPY",
+      "wsname": "ETH\/JPY",
+      "aclass_base": "currency",
+      "base": "XETH",
+      "aclass_quote": "currency",
+      "quote": "ZJPY",
+      "lot": "unit",
+      "pair_decimals": 0,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.02"
+    },
+    "XETHZJPY.d": {
+      "altname": "ETHJPY.d",
+      "aclass_base": "currency",
+      "base": "XETH",
+      "aclass_quote": "currency",
+      "quote": "ZJPY",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.36
+        ],
+        [
+          50000,
+          0.34
+        ],
+        [
+          100000,
+          0.32
+        ],
+        [
+          250000,
+          0.3
+        ],
+        [
+          500000,
+          0.28
+        ],
+        [
+          1000000,
+          0.26
+        ],
+        [
+          2500000,
+          0.24
+        ],
+        [
+          5000000,
+          0.22
+        ],
+        [
+          10000000,
+          0.2
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40
+    },
+    "XETHZUSD": {
+      "altname": "ETHUSD",
+      "wsname": "ETH\/USD",
+      "aclass_base": "currency",
+      "base": "XETH",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "leverage_sell": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.02"
+    },
+    "XETHZUSD.d": {
+      "altname": "ETHUSD.d",
+      "aclass_base": "currency",
+      "base": "XETH",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.36
+        ],
+        [
+          50000,
+          0.34
+        ],
+        [
+          100000,
+          0.32
+        ],
+        [
+          250000,
+          0.3
+        ],
+        [
+          500000,
+          0.28
+        ],
+        [
+          1000000,
+          0.26
+        ],
+        [
+          2500000,
+          0.24
+        ],
+        [
+          5000000,
+          0.22
+        ],
+        [
+          10000000,
+          0.2
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40
+    },
+    "XLTCXXBT": {
+      "altname": "LTCXBT",
+      "wsname": "LTC\/XBT",
+      "aclass_base": "currency",
+      "base": "XLTC",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "XLTCZEUR": {
+      "altname": "LTCEUR",
+      "wsname": "LTC\/EUR",
+      "aclass_base": "currency",
+      "base": "XLTC",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "XLTCZJPY": {
+      "altname": "LTCJPY",
+      "wsname": "LTC\/JPY",
+      "aclass_base": "currency",
+      "base": "XLTC",
+      "aclass_quote": "currency",
+      "quote": "ZJPY",
+      "lot": "unit",
+      "pair_decimals": 0,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "XLTCZUSD": {
+      "altname": "LTCUSD",
+      "wsname": "LTC\/USD",
+      "aclass_base": "currency",
+      "base": "XLTC",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "XMLNXETH": {
+      "altname": "MLNETH",
+      "wsname": "MLN\/ETH",
+      "aclass_base": "currency",
+      "base": "XMLN",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "XMLNXXBT": {
+      "altname": "MLNXBT",
+      "wsname": "MLN\/XBT",
+      "aclass_base": "currency",
+      "base": "XMLN",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "XMLNZEUR": {
+      "altname": "MLNEUR",
+      "wsname": "MLN\/EUR",
+      "aclass_base": "currency",
+      "base": "XMLN",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "XMLNZUSD": {
+      "altname": "MLNUSD",
+      "wsname": "MLN\/USD",
+      "aclass_base": "currency",
+      "base": "XMLN",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "XREPXETH": {
+      "altname": "REPETH",
+      "wsname": "REP\/ETH",
+      "aclass_base": "currency",
+      "base": "XREP",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.3"
+    },
+    "XREPXXBT": {
+      "altname": "REPXBT",
+      "wsname": "REP\/XBT",
+      "aclass_base": "currency",
+      "base": "XREP",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.3"
+    },
+    "XREPZEUR": {
+      "altname": "REPEUR",
+      "wsname": "REP\/EUR",
+      "aclass_base": "currency",
+      "base": "XREP",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.3"
+    },
+    "XREPZUSD": {
+      "altname": "REPUSD",
+      "wsname": "REP\/USD",
+      "aclass_base": "currency",
+      "base": "XREP",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.3"
+    },
+    "XRPAUD": {
+      "altname": "XRPAUD",
+      "wsname": "XRP\/AUD",
+      "aclass_base": "currency",
+      "base": "XXRP",
+      "aclass_quote": "currency",
+      "quote": "ZAUD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "30"
+    },
+    "XRPETH": {
+      "altname": "XRPETH",
+      "wsname": "XRP\/ETH",
+      "aclass_base": "currency",
+      "base": "XXRP",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "30"
+    },
+    "XRPGBP": {
+      "altname": "XRPGBP",
+      "wsname": "XRP\/GBP",
+      "aclass_base": "currency",
+      "base": "XXRP",
+      "aclass_quote": "currency",
+      "quote": "ZGBP",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "30"
+    },
+    "XRPUSDT": {
+      "altname": "XRPUSDT",
+      "wsname": "XRP\/USDT",
+      "aclass_base": "currency",
+      "base": "XXRP",
+      "aclass_quote": "currency",
+      "quote": "USDT",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "30"
+    },
+    "XTZETH": {
+      "altname": "XTZETH",
+      "wsname": "XTZ\/ETH",
+      "aclass_base": "currency",
+      "base": "XTZ",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "XTZEUR": {
+      "altname": "XTZEUR",
+      "wsname": "XTZ\/EUR",
+      "aclass_base": "currency",
+      "base": "XTZ",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "XTZUSD": {
+      "altname": "XTZUSD",
+      "wsname": "XTZ\/USD",
+      "aclass_base": "currency",
+      "base": "XTZ",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "XTZXBT": {
+      "altname": "XTZXBT",
+      "wsname": "XTZ\/XBT",
+      "aclass_base": "currency",
+      "base": "XTZ",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 7,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "1"
+    },
+    "XXBTZCAD": {
+      "altname": "XBTCAD",
+      "wsname": "XBT\/CAD",
+      "aclass_base": "currency",
+      "base": "XXBT",
+      "aclass_quote": "currency",
+      "quote": "ZCAD",
+      "lot": "unit",
+      "pair_decimals": 1,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.001"
+    },
+    "XXBTZCAD.d": {
+      "altname": "XBTCAD.d",
+      "aclass_base": "currency",
+      "base": "XXBT",
+      "aclass_quote": "currency",
+      "quote": "ZCAD",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.36
+        ],
+        [
+          50000,
+          0.34
+        ],
+        [
+          100000,
+          0.32
+        ],
+        [
+          250000,
+          0.3
+        ],
+        [
+          500000,
+          0.28
+        ],
+        [
+          1000000,
+          0.26
+        ],
+        [
+          2500000,
+          0.24
+        ],
+        [
+          5000000,
+          0.22
+        ],
+        [
+          10000000,
+          0.2
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40
+    },
+    "XXBTZEUR": {
+      "altname": "XBTEUR",
+      "wsname": "XBT\/EUR",
+      "aclass_base": "currency",
+      "base": "XXBT",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 1,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "leverage_sell": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.001"
+    },
+    "XXBTZEUR.d": {
+      "altname": "XBTEUR.d",
+      "aclass_base": "currency",
+      "base": "XXBT",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.36
+        ],
+        [
+          50000,
+          0.34
+        ],
+        [
+          100000,
+          0.32
+        ],
+        [
+          250000,
+          0.3
+        ],
+        [
+          500000,
+          0.28
+        ],
+        [
+          1000000,
+          0.26
+        ],
+        [
+          2500000,
+          0.24
+        ],
+        [
+          5000000,
+          0.22
+        ],
+        [
+          10000000,
+          0.2
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40
+    },
+    "XXBTZGBP": {
+      "altname": "XBTGBP",
+      "wsname": "XBT\/GBP",
+      "aclass_base": "currency",
+      "base": "XXBT",
+      "aclass_quote": "currency",
+      "quote": "ZGBP",
+      "lot": "unit",
+      "pair_decimals": 1,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.001"
+    },
+    "XXBTZGBP.d": {
+      "altname": "XBTGBP.d",
+      "aclass_base": "currency",
+      "base": "XXBT",
+      "aclass_quote": "currency",
+      "quote": "ZGBP",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.36
+        ],
+        [
+          50000,
+          0.34
+        ],
+        [
+          100000,
+          0.32
+        ],
+        [
+          250000,
+          0.3
+        ],
+        [
+          500000,
+          0.28
+        ],
+        [
+          1000000,
+          0.26
+        ],
+        [
+          2500000,
+          0.24
+        ],
+        [
+          5000000,
+          0.22
+        ],
+        [
+          10000000,
+          0.2
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40
+    },
+    "XXBTZJPY": {
+      "altname": "XBTJPY",
+      "wsname": "XBT\/JPY",
+      "aclass_base": "currency",
+      "base": "XXBT",
+      "aclass_quote": "currency",
+      "quote": "ZJPY",
+      "lot": "unit",
+      "pair_decimals": 0,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.001"
+    },
+    "XXBTZJPY.d": {
+      "altname": "XBTJPY.d",
+      "aclass_base": "currency",
+      "base": "XXBT",
+      "aclass_quote": "currency",
+      "quote": "ZJPY",
+      "lot": "unit",
+      "pair_decimals": 1,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.36
+        ],
+        [
+          50000,
+          0.34
+        ],
+        [
+          100000,
+          0.32
+        ],
+        [
+          250000,
+          0.3
+        ],
+        [
+          500000,
+          0.28
+        ],
+        [
+          1000000,
+          0.26
+        ],
+        [
+          2500000,
+          0.24
+        ],
+        [
+          5000000,
+          0.22
+        ],
+        [
+          10000000,
+          0.2
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40
+    },
+    "XXBTZUSD": {
+      "altname": "XBTUSD",
+      "wsname": "XBT\/USD",
+      "aclass_base": "currency",
+      "base": "XXBT",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 1,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "leverage_sell": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.001"
+    },
+    "XXBTZUSD.d": {
+      "altname": "XBTUSD.d",
+      "aclass_base": "currency",
+      "base": "XXBT",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.36
+        ],
+        [
+          50000,
+          0.34
+        ],
+        [
+          100000,
+          0.32
+        ],
+        [
+          250000,
+          0.3
+        ],
+        [
+          500000,
+          0.28
+        ],
+        [
+          1000000,
+          0.26
+        ],
+        [
+          2500000,
+          0.24
+        ],
+        [
+          5000000,
+          0.22
+        ],
+        [
+          10000000,
+          0.2
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40
+    },
+    "XXDGXXBT": {
+      "altname": "XDGXBT",
+      "wsname": "XDG\/XBT",
+      "aclass_base": "currency",
+      "base": "XXDG",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "3000"
+    },
+    "XXLMXXBT": {
+      "altname": "XLMXBT",
+      "wsname": "XLM\/XBT",
+      "aclass_base": "currency",
+      "base": "XXLM",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "30"
+    },
+    "XXLMZEUR": {
+      "altname": "XLMEUR",
+      "wsname": "XLM\/EUR",
+      "aclass_base": "currency",
+      "base": "XXLM",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "30"
+    },
+    "XXLMZUSD": {
+      "altname": "XLMUSD",
+      "wsname": "XLM\/USD",
+      "aclass_base": "currency",
+      "base": "XXLM",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "30"
+    },
+    "XXMRXXBT": {
+      "altname": "XMRXBT",
+      "wsname": "XMR\/XBT",
+      "aclass_base": "currency",
+      "base": "XXMR",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 6,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "XXMRZEUR": {
+      "altname": "XMREUR",
+      "wsname": "XMR\/EUR",
+      "aclass_base": "currency",
+      "base": "XXMR",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "XXMRZUSD": {
+      "altname": "XMRUSD",
+      "wsname": "XMR\/USD",
+      "aclass_base": "currency",
+      "base": "XXMR",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.1"
+    },
+    "XXRPXXBT": {
+      "altname": "XRPXBT",
+      "wsname": "XRP\/XBT",
+      "aclass_base": "currency",
+      "base": "XXRP",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 8,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3
+      ],
+      "leverage_sell": [
+        2,
+        3
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "30"
+    },
+    "XXRPZCAD": {
+      "altname": "XRPCAD",
+      "wsname": "XRP\/CAD",
+      "aclass_base": "currency",
+      "base": "XXRP",
+      "aclass_quote": "currency",
+      "quote": "ZCAD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "30"
+    },
+    "XXRPZEUR": {
+      "altname": "XRPEUR",
+      "wsname": "XRP\/EUR",
+      "aclass_base": "currency",
+      "base": "XXRP",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "leverage_sell": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "30"
+    },
+    "XXRPZJPY": {
+      "altname": "XRPJPY",
+      "wsname": "XRP\/JPY",
+      "aclass_base": "currency",
+      "base": "XXRP",
+      "aclass_quote": "currency",
+      "quote": "ZJPY",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "30"
+    },
+    "XXRPZUSD": {
+      "altname": "XRPUSD",
+      "wsname": "XRP\/USD",
+      "aclass_base": "currency",
+      "base": "XXRP",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "leverage_sell": [
+        2,
+        3,
+        4,
+        5
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "30"
+    },
+    "XZECXXBT": {
+      "altname": "ZECXBT",
+      "wsname": "ZEC\/XBT",
+      "aclass_base": "currency",
+      "base": "XZEC",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.03"
+    },
+    "XZECZEUR": {
+      "altname": "ZECEUR",
+      "wsname": "ZEC\/EUR",
+      "aclass_base": "currency",
+      "base": "XZEC",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.03"
+    },
+    "XZECZUSD": {
+      "altname": "ZECUSD",
+      "wsname": "ZEC\/USD",
+      "aclass_base": "currency",
+      "base": "XZEC",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [
+        2
+      ],
+      "leverage_sell": [
+        2
+      ],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.03"
+    },
+    "YFIETH": {
+      "altname": "YFIETH",
+      "wsname": "YFI\/ETH",
+      "aclass_base": "currency",
+      "base": "YFI",
+      "aclass_quote": "currency",
+      "quote": "XETH",
+      "lot": "unit",
+      "pair_decimals": 2,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.0001"
+    },
+    "YFIEUR": {
+      "altname": "YFIEUR",
+      "wsname": "YFI\/EUR",
+      "aclass_base": "currency",
+      "base": "YFI",
+      "aclass_quote": "currency",
+      "quote": "ZEUR",
+      "lot": "unit",
+      "pair_decimals": 0,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.0001"
+    },
+    "YFIUSD": {
+      "altname": "YFIUSD",
+      "wsname": "YFI\/USD",
+      "aclass_base": "currency",
+      "base": "YFI",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 0,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.0001"
+    },
+    "YFIXBT": {
+      "altname": "YFIXBT",
+      "wsname": "YFI\/XBT",
+      "aclass_base": "currency",
+      "base": "YFI",
+      "aclass_quote": "currency",
+      "quote": "XXBT",
+      "lot": "unit",
+      "pair_decimals": 4,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.26
+        ],
+        [
+          50000,
+          0.24
+        ],
+        [
+          100000,
+          0.22
+        ],
+        [
+          250000,
+          0.2
+        ],
+        [
+          500000,
+          0.18
+        ],
+        [
+          1000000,
+          0.16
+        ],
+        [
+          2500000,
+          0.14
+        ],
+        [
+          5000000,
+          0.12
+        ],
+        [
+          10000000,
+          0.1
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.16
+        ],
+        [
+          50000,
+          0.14
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.1
+        ],
+        [
+          500000,
+          0.08
+        ],
+        [
+          1000000,
+          0.06
+        ],
+        [
+          2500000,
+          0.04
+        ],
+        [
+          5000000,
+          0.02
+        ],
+        [
+          10000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "0.0001"
+    },
+    "ZEURZUSD": {
+      "altname": "EURUSD",
+      "wsname": "EUR\/USD",
+      "aclass_base": "currency",
+      "base": "ZEUR",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "ZGBPZUSD": {
+      "altname": "GBPUSD",
+      "wsname": "GBP\/USD",
+      "aclass_base": "currency",
+      "base": "ZGBP",
+      "aclass_quote": "currency",
+      "quote": "ZUSD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "ZUSDZCAD": {
+      "altname": "USDCAD",
+      "wsname": "USD\/CAD",
+      "aclass_base": "currency",
+      "base": "ZUSD",
+      "aclass_quote": "currency",
+      "quote": "ZCAD",
+      "lot": "unit",
+      "pair_decimals": 5,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    },
+    "ZUSDZJPY": {
+      "altname": "USDJPY",
+      "wsname": "USD\/JPY",
+      "aclass_base": "currency",
+      "base": "ZUSD",
+      "aclass_quote": "currency",
+      "quote": "ZJPY",
+      "lot": "unit",
+      "pair_decimals": 3,
+      "lot_decimals": 8,
+      "lot_multiplier": 1,
+      "leverage_buy": [],
+      "leverage_sell": [],
+      "fees": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fees_maker": [
+        [
+          0,
+          0.2
+        ],
+        [
+          50000,
+          0.16
+        ],
+        [
+          100000,
+          0.12
+        ],
+        [
+          250000,
+          0.08
+        ],
+        [
+          500000,
+          0.04
+        ],
+        [
+          1000000,
+          0
+        ]
+      ],
+      "fee_volume_currency": "ZUSD",
+      "margin_call": 80,
+      "margin_stop": 40,
+      "ordermin": "10"
+    }
+  }
+}

--- a/bxbot-exchanges/src/test/java/com/gazbert/bxbot/exchanges/TestKrakenExchangeAdapter.java
+++ b/bxbot-exchanges/src/test/java/com/gazbert/bxbot/exchanges/TestKrakenExchangeAdapter.java
@@ -23,6 +23,7 @@
 
 package com.gazbert.bxbot.exchanges;
 
+import static java.util.Collections.emptyMap;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.eq;
@@ -38,6 +39,7 @@ import com.gazbert.bxbot.exchange.api.ExchangeAdapter;
 import com.gazbert.bxbot.exchange.api.ExchangeConfig;
 import com.gazbert.bxbot.exchange.api.NetworkConfig;
 import com.gazbert.bxbot.exchange.api.OtherConfig;
+import com.gazbert.bxbot.exchanges.AbstractExchangeAdapter.ExchangeHttpResponse;
 import com.gazbert.bxbot.trading.api.BalanceInfo;
 import com.gazbert.bxbot.trading.api.ExchangeNetworkException;
 import com.gazbert.bxbot.trading.api.MarketOrderBook;
@@ -45,6 +47,7 @@ import com.gazbert.bxbot.trading.api.OpenOrder;
 import com.gazbert.bxbot.trading.api.OrderType;
 import com.gazbert.bxbot.trading.api.Ticker;
 import com.gazbert.bxbot.trading.api.TradingApiException;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.net.URL;
@@ -81,6 +84,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @PrepareForTest(KrakenExchangeAdapter.class)
 public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
 
+  private static final String ASSET_PAIR_JSON_RESPONSE
+      = "./src/test/exchange-data/kraken/AssetPairs.json";
   private static final String DEPTH_JSON_RESPONSE = "./src/test/exchange-data/kraken/Depth.json";
   private static final String DEPTH_ERROR_JSON_RESPONSE =
       "./src/test/exchange-data/kraken/Depth-error.json";
@@ -109,6 +114,7 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
   private static final String DEPTH = "Depth";
   private static final String BALANCE = "Balance";
   private static final String TICKER = "Ticker";
+  private static final String ASSET_PAIRS = "AssetPairs";
   private static final String OPEN_ORDERS = "OpenOrders";
   private static final String ADD_ORDER = "AddOrder";
   private static final String CANCEL_ORDER = "CancelOrder";
@@ -202,6 +208,7 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
             MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD,
             MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD);
 
+    mockAssetPairsPublicRequest(exchangeAdapter);
     PowerMock.expectPrivate(exchangeAdapter, MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD)
         .andReturn(requestParamMap);
     PowerMock.expectPrivate(
@@ -259,6 +266,7 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
             MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD,
             MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD);
 
+    mockAssetPairsPublicRequest(exchangeAdapter);
     PowerMock.expectPrivate(exchangeAdapter, MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD)
         .andReturn(requestParamMap);
     PowerMock.expectPrivate(
@@ -281,6 +289,7 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
         PowerMock.createPartialMockAndInvokeDefaultConstructor(
             KrakenExchangeAdapter.class, MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD);
 
+    mockAssetPairsPublicRequest(exchangeAdapter);
     PowerMock.expectPrivate(
             exchangeAdapter,
             MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD,
@@ -302,6 +311,7 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
         PowerMock.createPartialMockAndInvokeDefaultConstructor(
             KrakenExchangeAdapter.class, MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD);
 
+    mockAssetPairsPublicRequest(exchangeAdapter);
     PowerMock.expectPrivate(
             exchangeAdapter,
             MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD,
@@ -453,12 +463,12 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
     expect(
             requestParamMap.put(
                 "price",
-                new DecimalFormat("#.########", getDecimalFormatSymbols()).format(BUY_ORDER_PRICE)))
+                new DecimalFormat("#.#", getDecimalFormatSymbols()).format(BUY_ORDER_PRICE)))
         .andStubReturn(null);
     expect(
             requestParamMap.put(
                 "volume",
-                new DecimalFormat("#.########", getDecimalFormatSymbols())
+                new DecimalFormat("#.###", getDecimalFormatSymbols())
                     .format(BUY_ORDER_QUANTITY)))
         .andStubReturn(null);
 
@@ -466,8 +476,10 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
         PowerMock.createPartialMockAndInvokeDefaultConstructor(
             KrakenExchangeAdapter.class,
             MOCKED_SEND_AUTHENTICATED_REQUEST_TO_EXCHANGE_METHOD,
+            MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD,
             MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD);
 
+    mockAssetPairsPublicRequest(exchangeAdapter);
     PowerMock.expectPrivate(exchangeAdapter, MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD)
         .andReturn(requestParamMap);
     PowerMock.expectPrivate(
@@ -502,13 +514,13 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
     expect(
             requestParamMap.put(
                 "price",
-                new DecimalFormat("#.########", getDecimalFormatSymbols())
+                new DecimalFormat("#.#", getDecimalFormatSymbols())
                     .format(SELL_ORDER_PRICE)))
         .andStubReturn(null);
     expect(
             requestParamMap.put(
                 "volume",
-                new DecimalFormat("#.########", getDecimalFormatSymbols())
+                new DecimalFormat("#.###", getDecimalFormatSymbols())
                     .format(SELL_ORDER_QUANTITY)))
         .andStubReturn(null);
 
@@ -516,8 +528,10 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
         PowerMock.createPartialMockAndInvokeDefaultConstructor(
             KrakenExchangeAdapter.class,
             MOCKED_SEND_AUTHENTICATED_REQUEST_TO_EXCHANGE_METHOD,
+            MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD,
             MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD);
 
+    mockAssetPairsPublicRequest(exchangeAdapter);
     PowerMock.expectPrivate(exchangeAdapter, MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD)
         .andReturn(requestParamMap);
     PowerMock.expectPrivate(
@@ -842,6 +856,7 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
             MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD,
             MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD);
 
+    mockAssetPairsPublicRequest(exchangeAdapter);
     PowerMock.expectPrivate(exchangeAdapter, MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD)
         .andReturn(requestParamMap);
     PowerMock.expectPrivate(
@@ -870,6 +885,7 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
     final KrakenExchangeAdapter exchangeAdapter =
         PowerMock.createPartialMockAndInvokeDefaultConstructor(
             KrakenExchangeAdapter.class, MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD);
+    mockAssetPairsPublicRequest(exchangeAdapter);
     PowerMock.expectPrivate(
             exchangeAdapter,
             MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD,
@@ -889,6 +905,7 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
     final KrakenExchangeAdapter exchangeAdapter =
         PowerMock.createPartialMockAndInvokeDefaultConstructor(
             KrakenExchangeAdapter.class, MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD);
+    mockAssetPairsPublicRequest(exchangeAdapter);
     PowerMock.expectPrivate(
             exchangeAdapter,
             MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD,
@@ -913,6 +930,7 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
     final KrakenExchangeAdapter exchangeAdapter =
         PowerMock.createPartialMockAndInvokeDefaultConstructor(
             KrakenExchangeAdapter.class, MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD);
+    mockAssetPairsPublicRequest(exchangeAdapter);
     PowerMock.expectPrivate(
             exchangeAdapter,
             MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD,
@@ -953,6 +971,7 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
             MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD,
             MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD);
 
+    mockAssetPairsPublicRequest(exchangeAdapter);
     PowerMock.expectPrivate(exchangeAdapter, MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD)
         .andReturn(requestParamMap);
     PowerMock.expectPrivate(
@@ -989,6 +1008,7 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
     final KrakenExchangeAdapter exchangeAdapter =
         PowerMock.createPartialMockAndInvokeDefaultConstructor(
             KrakenExchangeAdapter.class, MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD);
+    mockAssetPairsPublicRequest(exchangeAdapter);
     PowerMock.expectPrivate(
             exchangeAdapter,
             MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD,
@@ -1008,6 +1028,7 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
     final KrakenExchangeAdapter exchangeAdapter =
         PowerMock.createPartialMockAndInvokeDefaultConstructor(
             KrakenExchangeAdapter.class, MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD);
+    mockAssetPairsPublicRequest(exchangeAdapter);
     PowerMock.expectPrivate(
             exchangeAdapter,
             MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD,
@@ -1027,6 +1048,7 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
     final KrakenExchangeAdapter exchangeAdapter =
         PowerMock.createPartialMockAndInvokeDefaultConstructor(
             KrakenExchangeAdapter.class, MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD);
+    mockAssetPairsPublicRequest(exchangeAdapter);
     PowerMock.expectPrivate(
             exchangeAdapter,
             MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD,
@@ -1146,8 +1168,8 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
         PowerMock.createPartialMockAndInvokeDefaultConstructor(
             KrakenExchangeAdapter.class,
             MOCKED_MAKE_NETWORK_REQUEST_METHOD,
-            MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD,
             MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD);
+    mockAssetPairsNetworkRequest(exchangeAdapter);
     PowerMock.expectPrivate(exchangeAdapter, MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD)
         .andReturn(requestParamMap);
 
@@ -1178,6 +1200,7 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
             KrakenExchangeAdapter.class,
             MOCKED_MAKE_NETWORK_REQUEST_METHOD,
             MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD);
+    mockAssetPairsNetworkRequest(exchangeAdapter);
 
     final Map<String, String> requestParamMap = PowerMock.createPartialMock(HashMap.class, "put");
     expect(requestParamMap.put("pair", MARKET_ID)).andStubReturn(null);
@@ -1214,6 +1237,7 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
             MOCKED_MAKE_NETWORK_REQUEST_METHOD,
             MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD,
             MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD);
+    mockAssetPairsNetworkRequest(exchangeAdapter);
 
     final Map<String, String> requestParamMap = PowerMock.createPartialMock(HashMap.class, "put");
     expect(requestParamMap.put("pair", MARKET_ID)).andStubReturn(null);
@@ -1259,13 +1283,13 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
     expect(
             requestParamMap.put(
                 "price",
-                new DecimalFormat("#.########", getDecimalFormatSymbols())
+                new DecimalFormat("#.#", getDecimalFormatSymbols())
                     .format(SELL_ORDER_PRICE)))
         .andStubReturn(null);
     expect(
             requestParamMap.put(
                 "volume",
-                new DecimalFormat("#.########", getDecimalFormatSymbols())
+                new DecimalFormat("#.###", getDecimalFormatSymbols())
                     .format(SELL_ORDER_QUANTITY)))
         .andStubReturn(null);
     expect(requestParamMap.put(eq("nonce"), anyString())).andStubReturn(null);
@@ -1283,6 +1307,9 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
             MOCKED_MAKE_NETWORK_REQUEST_METHOD,
             MOCKED_CREATE_REQUEST_HEADER_MAP_METHOD,
             MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD);
+    mockAssetPairsNetworkRequest(exchangeAdapter);
+    PowerMock.expectPrivate(exchangeAdapter, MOCKED_CREATE_REQUEST_HEADER_MAP_METHOD)
+        .andReturn(emptyMap());
     PowerMock.expectPrivate(exchangeAdapter, MOCKED_CREATE_REQUEST_HEADER_MAP_METHOD)
         .andReturn(requestHeaderMap);
     PowerMock.expectPrivate(exchangeAdapter, MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD)
@@ -1320,13 +1347,13 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
     expect(
             requestParamMap.put(
                 "price",
-                new DecimalFormat("#.########", getDecimalFormatSymbols())
+                new DecimalFormat("#.#", getDecimalFormatSymbols())
                     .format(SELL_ORDER_PRICE)))
         .andStubReturn(null);
     expect(
             requestParamMap.put(
                 "volume",
-                new DecimalFormat("#.########", getDecimalFormatSymbols())
+                new DecimalFormat("#.###", getDecimalFormatSymbols())
                     .format(SELL_ORDER_QUANTITY)))
         .andStubReturn(null);
     expect(requestParamMap.put(eq("nonce"), anyString())).andStubReturn(null);
@@ -1344,6 +1371,9 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
             MOCKED_MAKE_NETWORK_REQUEST_METHOD,
             MOCKED_CREATE_REQUEST_HEADER_MAP_METHOD,
             MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD);
+    mockAssetPairsNetworkRequest(exchangeAdapter);
+    PowerMock.expectPrivate(exchangeAdapter, MOCKED_CREATE_REQUEST_HEADER_MAP_METHOD)
+        .andReturn(emptyMap());
     PowerMock.expectPrivate(exchangeAdapter, MOCKED_CREATE_REQUEST_HEADER_MAP_METHOD)
         .andReturn(requestHeaderMap);
     PowerMock.expectPrivate(exchangeAdapter, MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD)
@@ -1378,13 +1408,13 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
     expect(
             requestParamMap.put(
                 "price",
-                new DecimalFormat("#.########", getDecimalFormatSymbols())
+                new DecimalFormat("#.#", getDecimalFormatSymbols())
                     .format(SELL_ORDER_PRICE)))
         .andStubReturn(null);
     expect(
             requestParamMap.put(
                 "volume",
-                new DecimalFormat("#.########", getDecimalFormatSymbols())
+                new DecimalFormat("#.###", getDecimalFormatSymbols())
                     .format(SELL_ORDER_QUANTITY)))
         .andStubReturn(null);
     expect(requestParamMap.put(eq("nonce"), anyString())).andStubReturn(null);
@@ -1402,6 +1432,9 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
             MOCKED_MAKE_NETWORK_REQUEST_METHOD,
             MOCKED_CREATE_REQUEST_HEADER_MAP_METHOD,
             MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD);
+    mockAssetPairsNetworkRequest(exchangeAdapter);
+    PowerMock.expectPrivate(exchangeAdapter, MOCKED_CREATE_REQUEST_HEADER_MAP_METHOD)
+        .andReturn(emptyMap());
     PowerMock.expectPrivate(exchangeAdapter, MOCKED_CREATE_REQUEST_HEADER_MAP_METHOD)
         .andReturn(requestHeaderMap);
     PowerMock.expectPrivate(exchangeAdapter, MOCKED_CREATE_REQUEST_PARAM_MAP_METHOD)
@@ -1429,5 +1462,36 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
     exchangeAdapter.createOrder(MARKET_ID, OrderType.SELL, SELL_ORDER_QUANTITY, SELL_ORDER_PRICE);
 
     PowerMock.verifyAll();
+  }
+
+  private void mockAssetPairsPublicRequest(Object exchangeAdapter) throws Exception {
+    final ExchangeHttpResponse assetsResponse = createMockAssetPairs();
+    PowerMock.expectPrivate(
+        exchangeAdapter,
+        MOCKED_SEND_PUBLIC_REQUEST_TO_EXCHANGE_METHOD,
+        eq(ASSET_PAIRS),
+        anyObject()
+    ).andReturn(assetsResponse);
+  }
+
+  private void mockAssetPairsNetworkRequest(Object exchangeAdapter) throws Exception {
+    final ExchangeHttpResponse assetsResponse = createMockAssetPairs();
+    final URL url = new URL(PUBLIC_API_BASE_URL + ASSET_PAIRS);
+    PowerMock.expectPrivate(
+        exchangeAdapter,
+        MOCKED_MAKE_NETWORK_REQUEST_METHOD,
+        eq(url),
+        eq("GET"),
+        anyObject(),
+        anyObject()
+    ).andReturn(assetsResponse);
+  }
+
+  private ExchangeHttpResponse createMockAssetPairs() throws IOException {
+    final byte[] assetsMsg = Files.readAllBytes(Paths.get(
+        TestKrakenExchangeAdapter.ASSET_PAIR_JSON_RESPONSE));
+
+    return new ExchangeHttpResponse(200, "OK",
+        new String(assetsMsg, StandardCharsets.UTF_8));
   }
 }


### PR DESCRIPTION
Added a way for the Kraken adaptor to fetch the configuration from [decimal values precision](https://support.kraken.com/hc/en-us/articles/360001389366-Price-and-volume-decimal-precision) and place order accordingly.

Fixes #126