### PR TITLE
Feature/ta4j backtesting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,8 @@ ext.libraries = [
         jjwt                                    : dependencies.create("io.jsonwebtoken:jjwt:0.9.1"),
         google_guava                            : dependencies.create("com.google.guava:guava:30.1-jre"),
         google_gson                             : dependencies.create("com.google.code.gson:gson:2.8.6"),
+        ta4j                                    : dependencies.create("org.ta4j:ta4j-core:0.13"),
+        jfreechart                              : dependencies.create("org.jfree:jfreechart:1.0.17"),
         h2                                      : dependencies.create("com.h2database:h2:1.4.200"),
         javax_mail_api                          : dependencies.create("javax.mail:javax.mail-api:" + ext.versions.javaxMailVersion),
         javax_mail_sun                          : dependencies.create("com.sun.mail:javax.mail:" + ext.versions.javaxMailVersion),

--- a/bxbot-exchanges/build.gradle
+++ b/bxbot-exchanges/build.gradle
@@ -11,6 +11,8 @@ dependencies {
     compile libraries.google_guava
     compile libraries.javax_xml_api
     compile libraries.javax_xml_impl
+    compile libraries.ta4j
+    compile libraries.jfreechart
 
     testCompile libraries.junit
     testCompile libraries.powermock_junit

--- a/bxbot-exchanges/pom.xml
+++ b/bxbot-exchanges/pom.xml
@@ -85,6 +85,14 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.ta4j</groupId>
+      <artifactId>ta4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jfree</groupId>
+      <artifactId>jfreechart</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
     </dependency>

--- a/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/TA4JRecordingAdapter.java
+++ b/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/TA4JRecordingAdapter.java
@@ -1,0 +1,274 @@
+package com.gazbert.bxbot.exchanges;
+
+import com.gazbert.bxbot.exchange.api.ExchangeAdapter;
+import com.gazbert.bxbot.exchange.api.ExchangeConfig;
+import com.gazbert.bxbot.exchange.api.OtherConfig;
+import com.gazbert.bxbot.exchanges.ta4jhelper.*;
+import com.gazbert.bxbot.exchanges.trading.api.impl.BalanceInfoImpl;
+import com.gazbert.bxbot.exchanges.trading.api.impl.OpenOrderImpl;
+import com.gazbert.bxbot.exchanges.trading.api.impl.TickerImpl;
+import com.gazbert.bxbot.trading.api.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.ta4j.core.*;
+import org.ta4j.core.cost.LinearTransactionCostModel;
+import org.ta4j.core.tradereport.PerformanceReport;
+import org.ta4j.core.tradereport.TradeStatsReport;
+import org.ta4j.core.tradereport.TradingStatement;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.*;
+
+public class TA4JRecordingAdapter extends AbstractExchangeAdapter implements ExchangeAdapter {
+    private static final Logger LOG = LogManager.getLogger();
+    private static final String BUY_FEE_PROPERTY_NAME = "buy-fee";
+    private static final String SELL_FEE_PROPERTY_NAME = "sell-fee";
+
+
+    private BigDecimal buyFeePercentage;
+    private BigDecimal sellFeePercentage;
+    private BigDecimal sellLimitDistancePercentage;
+    private String tradingSeriesTradingPath;
+
+
+    private BarSeries tradingSeries;
+
+    private static final String counterCurrency = "ZEUR";
+    private static final String baseCurrency = "XXRP";
+    private static final String marketID = "XRPEUR";
+
+    private BigDecimal baseCurrencyBalance = BigDecimal.ZERO;
+    private BigDecimal counterCurrencyBalance = new BigDecimal(100); // simulated starting balance
+    private OpenOrder currentOpenOrder;
+    private int currentTick;
+    private final TA4JRecordingRule sellOrderRule = new TA4JRecordingRule();
+    private final TA4JRecordingRule buyOrderRule = new TA4JRecordingRule();
+
+    @Override
+    public void init(ExchangeConfig config) {
+        LOG.info(() -> "About to initialise ta4j recording ExchangeConfig: " + config);
+        setOtherConfig(config);
+        loadRecodingSeriesFromJson();
+        currentTick = tradingSeries.getBeginIndex() - 1;
+    }
+
+    private void loadRecodingSeriesFromJson() {
+        tradingSeries = JsonBarsSerializer.loadSeries(tradingSeriesTradingPath);
+        if(tradingSeries == null || tradingSeries.isEmpty()) {
+            throw new IllegalArgumentException("Could not load ta4j series from json '" + tradingSeriesTradingPath + "'");
+        }
+    }
+
+    private void setOtherConfig(ExchangeConfig exchangeConfig) {
+        final OtherConfig otherConfig = getOtherConfig(exchangeConfig);
+
+        final String buyFeeInConfig = getOtherConfigItem(otherConfig, BUY_FEE_PROPERTY_NAME);
+        buyFeePercentage =
+                new BigDecimal(buyFeeInConfig).divide(new BigDecimal("100"), 8, RoundingMode.HALF_UP);
+        LOG.info(() -> "Buy fee % in BigDecimal format: " + buyFeePercentage);
+
+        final String sellFeeInConfig = getOtherConfigItem(otherConfig, SELL_FEE_PROPERTY_NAME);
+        sellFeePercentage =
+                new BigDecimal(sellFeeInConfig).divide(new BigDecimal("100"), 8, RoundingMode.HALF_UP);
+        LOG.info(() -> "Sell fee % in BigDecimal format: " + sellFeePercentage);
+
+        final String sellLimitDistanceInConfig = getOtherConfigItem(otherConfig, "sell-stop-limit-percentage-distance");
+        sellLimitDistancePercentage =
+                new BigDecimal(sellLimitDistanceInConfig).divide(new BigDecimal("100"), 8, RoundingMode.HALF_UP);
+        LOG.info(() -> "Sell (stop-limit order) limit distance % in BigDecimal format: " + sellLimitDistancePercentage);
+
+        tradingSeriesTradingPath = getOtherConfigItem(otherConfig, "trading-series-json-path");
+        LOG.info(() -> "path to load series json from for recording:" + tradingSeriesTradingPath);
+    }
+
+    @Override
+    public String getImplName() {
+        return "ta4j recording and analyzing adapter";
+    }
+
+    @Override
+    public MarketOrderBook getMarketOrders(String marketId) throws ExchangeNetworkException, TradingApiException {
+        throw new TradingApiException("get market orders is not implemented", new UnsupportedOperationException());
+    }
+
+    @Override
+    public List<OpenOrder> getYourOpenOrders(String marketId) throws ExchangeNetworkException, TradingApiException {
+        LinkedList<OpenOrder> result = new LinkedList<>();
+        if (currentOpenOrder != null) {
+            result.add(currentOpenOrder);
+        }
+        return result;
+    }
+
+    @Override
+    public String createOrder(String marketId, OrderType orderType, BigDecimal quantity, BigDecimal price) throws ExchangeNetworkException, TradingApiException {
+        if (!marketID.equals(marketId)) {
+            throw new TradingApiException("Market did not match. Expected: "+ marketID+ ", actual: " + marketId);
+        }
+        if (currentOpenOrder != null) {
+            throw new TradingApiException("Can only record/execute one order at a time. Wait for the open order to fulfill");
+        }
+        String newOrderID = "DUMMY_" + orderType + "_ORDER_ID_" + System.currentTimeMillis();
+        Date creationDate = Date.from(tradingSeries.getBar(currentTick).getEndTime().toInstant());
+        BigDecimal total = price.multiply(quantity);
+        currentOpenOrder = new OpenOrderImpl(newOrderID, creationDate, marketId, orderType, price, quantity, quantity, total);
+        checkOpenOrderExecution();
+        return newOrderID;
+    }
+
+    @Override
+    public boolean cancelOrder(String orderId, String marketId) throws ExchangeNetworkException, TradingApiException {
+        if (!marketID.equals(marketId)) {
+            throw new TradingApiException("Market did not match. Expected: "+ marketID+ ", actual: " + marketId);
+        }
+        if (currentOpenOrder == null) {
+            throw new TradingApiException("Tried to cancel a order, but no open order found");
+        }
+        if (!currentOpenOrder.getId().equals(orderId)) {
+            throw new TradingApiException("Tried to cancel a order, but the order id does not match the current open order. Expected: " + currentOpenOrder.getId() + ", actual: " + orderId);
+        }
+        currentOpenOrder = null;
+        return true;
+    }
+
+    @Override
+    public BigDecimal getLatestMarketPrice(String marketId) throws ExchangeNetworkException, TradingApiException {
+        return (BigDecimal) tradingSeries.getBar(currentTick).getClosePrice().getDelegate();
+    }
+
+    @Override
+    public BalanceInfo getBalanceInfo() throws ExchangeNetworkException, TradingApiException {
+        HashMap<String, BigDecimal> availableBalances = new HashMap<>();
+        availableBalances.put(baseCurrency, baseCurrencyBalance);
+        availableBalances.put(counterCurrency, counterCurrencyBalance);
+        return new BalanceInfoImpl(availableBalances, new HashMap<>());
+    }
+
+    @Override
+    public Ticker getTicker(String marketId) throws TradingApiException, ExchangeNetworkException {
+        currentTick++;
+        LOG.info("Tick increased to '" + currentTick + "'");
+        if (currentTick > tradingSeries.getEndIndex()) {
+            finishRecording();
+            return null;
+        }
+
+        checkOpenOrderExecution();
+
+        Bar currentBar = tradingSeries.getBar(currentTick);
+        BigDecimal last = (BigDecimal) currentBar.getClosePrice().getDelegate();
+        BigDecimal bid = (BigDecimal) currentBar.getLowPrice().getDelegate();
+        BigDecimal ask = (BigDecimal) currentBar.getHighPrice().getDelegate();
+        BigDecimal low = (BigDecimal) currentBar.getLowPrice().getDelegate();
+        BigDecimal high = (BigDecimal) currentBar.getHighPrice().getDelegate();
+        BigDecimal open = (BigDecimal) currentBar.getOpenPrice().getDelegate();
+        BigDecimal volume = (BigDecimal) currentBar.getVolume().getDelegate();
+        BigDecimal vwap = BigDecimal.ZERO;
+        Long timestamp = currentBar.getEndTime().toEpochSecond();
+        return new TickerImpl(last, bid, ask, low, high, open, volume, vwap, timestamp);
+    }
+
+    private void checkOpenOrderExecution() throws TradingApiException, ExchangeNetworkException {
+        if (currentOpenOrder != null) {
+            switch (currentOpenOrder.getType()) {
+                case BUY:
+                    checkOpenBuyOrderExecution();
+                    break;
+                case SELL:
+                    checkOpenSellOrderExecution();
+                    break;
+                default:
+                    throw new TradingApiException("Order type not recognized: " +currentOpenOrder.getType());
+            }
+        }
+    }
+
+    private void checkOpenSellOrderExecution() throws TradingApiException, ExchangeNetworkException {
+        BigDecimal currentBidPrice = (BigDecimal)tradingSeries.getBar(currentTick).getLowPrice().getDelegate();
+        if (currentBidPrice.compareTo(currentOpenOrder.getPrice()) <= 0) {
+            LOG.info("SELL: the bid price is below or equal to the stop price --> record sell order execution with the bid price");
+            sellOrderRule.addTrigger(currentTick);
+            BigDecimal orderPrice = currentOpenOrder.getOriginalQuantity().multiply(currentBidPrice);
+            BigDecimal buyFees = getPercentageOfSellOrderTakenForExchangeFee(marketID).multiply(orderPrice);
+            BigDecimal netOrderPrice = orderPrice.subtract(buyFees);
+            counterCurrencyBalance = counterCurrencyBalance.add(netOrderPrice);
+            baseCurrencyBalance = baseCurrencyBalance.subtract(currentOpenOrder.getOriginalQuantity());
+            currentOpenOrder = null;
+        }
+    }
+
+    private void checkOpenBuyOrderExecution() throws TradingApiException, ExchangeNetworkException {
+        BigDecimal currentAskPrice = (BigDecimal)tradingSeries.getBar(currentTick).getHighPrice().getDelegate();
+        if (currentAskPrice.compareTo(currentOpenOrder.getPrice()) <=0) {
+            LOG.info("BUY: the current ask price is below or queal to the limit price --> record buy order execution with the current ask price");
+            buyOrderRule.addTrigger(currentTick);
+            BigDecimal orderPrice = currentOpenOrder.getOriginalQuantity().multiply(currentAskPrice);
+            BigDecimal buyFees = getPercentageOfBuyOrderTakenForExchangeFee(marketID).multiply(orderPrice);
+            BigDecimal netOrderPrice = orderPrice.add(buyFees);
+            counterCurrencyBalance = counterCurrencyBalance.subtract(netOrderPrice);
+            baseCurrencyBalance = baseCurrencyBalance.add(currentOpenOrder.getOriginalQuantity());
+            currentOpenOrder = null;
+        }
+    }
+
+
+    private void finishRecording() throws TradingApiException, ExchangeNetworkException {
+        final List<Strategy> strategies = new ArrayList<>();
+        Strategy strategy = new BaseStrategy("Recorded ta4j trades", buyOrderRule, sellOrderRule);
+        strategies.add(strategy);
+        Ta4jOptimalTradingStrategy optimalTradingStrategy = new Ta4jOptimalTradingStrategy(tradingSeries, getPercentageOfBuyOrderTakenForExchangeFee(marketID), getPercentageOfSellOrderTakenForExchangeFee(marketID));
+        strategies.add(optimalTradingStrategy);
+
+        TradePriceRespectingBacktestExecutor backtestExecutor = new TradePriceRespectingBacktestExecutor(tradingSeries, new LinearTransactionCostModel(getPercentageOfBuyOrderTakenForExchangeFee(marketID).doubleValue()));
+        List<TradingStatement> statements = backtestExecutor.execute(strategies, tradingSeries.numOf(25), Order.OrderType.BUY);
+        logReports(statements);
+        BuyAndSellSignalsToChart.printSeries(tradingSeries, strategy);
+        BuyAndSellSignalsToChart.printSeries(tradingSeries, optimalTradingStrategy);
+        throw new TradingApiException("Simulation end finished. Ending balance: " + getBalanceInfo());
+    }
+
+    private void logReports(List<TradingStatement> statements) {
+        for(TradingStatement statement:statements) {
+            LOG.info( () ->
+            "\n######### "+statement.getStrategy().getName()+" #########\n" +
+            createPerformanceReport(statement) + "\n" +
+            createTradesReport(statement)+ "\n"+
+                    "###########################"
+            );
+        }
+    }
+
+    private String createTradesReport(TradingStatement statement) {
+        TradeStatsReport tradeStatsReport = statement.getTradeStatsReport();
+        return "--------- trade statistics report ---------\n" +
+                "loss trade count: " + tradeStatsReport.getLossTradeCount() + "\n" +
+                "profit trade count: " + tradeStatsReport.getProfitTradeCount() + "\n" +
+                "break even trade count: " + tradeStatsReport.getBreakEvenTradeCount() + "\n" +
+                "---------------------------";
+    }
+
+    private String createPerformanceReport(TradingStatement statement) {
+        PerformanceReport performanceReport = statement.getPerformanceReport();
+        return "--------- performance report ---------\n" +
+                "total loss: " + performanceReport.getTotalLoss() + "\n" +
+                "total profit: " + performanceReport.getTotalProfit() + "\n" +
+                "total profit loss: " + performanceReport.getTotalProfitLoss() + "\n" +
+                "total profit loss percentage: " + performanceReport.getTotalProfitLossPercentage() + "\n" +
+                "---------------------------";
+    }
+
+    @Override
+    public BigDecimal getPercentageOfBuyOrderTakenForExchangeFee(String marketId) throws TradingApiException, ExchangeNetworkException {
+        return buyFeePercentage;
+    }
+
+    @Override
+    public BigDecimal getPercentageOfSellOrderTakenForExchangeFee(String marketId) throws TradingApiException, ExchangeNetworkException {
+        return sellFeePercentage;
+    }
+
+    public int getMaxIndex() {
+        return tradingSeries.getEndIndex();
+    }
+}

--- a/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/TA4JRecordingAdapter.java
+++ b/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/TA4JRecordingAdapter.java
@@ -24,21 +24,24 @@ public class TA4JRecordingAdapter extends AbstractExchangeAdapter implements Exc
     private static final Logger LOG = LogManager.getLogger();
     private static final String BUY_FEE_PROPERTY_NAME = "buy-fee";
     private static final String SELL_FEE_PROPERTY_NAME = "sell-fee";
+    private static final String SIMULATED_COUNTER_CURRENCY_PROPERTY_NAME = "simulatedCounterCurrency";
+    private static final String COUNTER_CURRENCY_START_BALANCE_PROPERTY_NAME = "counterCurrencyStartingBalance";
+    private static final String SIMULATED_BASE_CURRENCY_PROPERTY_NAME = "simulatedBaseCurrency";
 
 
     private BigDecimal buyFeePercentage;
     private BigDecimal sellFeePercentage;
     private BigDecimal sellLimitDistancePercentage;
     private String tradingSeriesTradingPath;
-
+    private String simulatedCounterCurrency;
+    private String simulatedBaseCurrency;
 
     private BarSeries tradingSeries;
 
-    private static final String counterCurrency = "ZEUR";
-    private static final String baseCurrency = "XXRP";
+
 
     private BigDecimal baseCurrencyBalance = BigDecimal.ZERO;
-    private BigDecimal counterCurrencyBalance = new BigDecimal(100); // simulated starting balance
+    private BigDecimal counterCurrencyBalance;
     private OpenOrder currentOpenOrder;
     private int currentTick;
     private final TA4JRecordingRule sellOrderRule = new TA4JRecordingRule();
@@ -79,6 +82,16 @@ public class TA4JRecordingAdapter extends AbstractExchangeAdapter implements Exc
 
         tradingSeriesTradingPath = getOtherConfigItem(otherConfig, "trading-series-json-path");
         LOG.info(() -> "path to load series json from for recording:" + tradingSeriesTradingPath);
+
+        simulatedBaseCurrency = getOtherConfigItem(otherConfig, SIMULATED_BASE_CURRENCY_PROPERTY_NAME);
+        LOG.info(() -> "Base currency to be simulated:" + simulatedBaseCurrency);
+
+        simulatedCounterCurrency = getOtherConfigItem(otherConfig, SIMULATED_COUNTER_CURRENCY_PROPERTY_NAME);
+        LOG.info(() -> "Counter currency to be simulated:" + simulatedCounterCurrency);
+
+        final String startingBalanceInConfig = getOtherConfigItem(otherConfig, COUNTER_CURRENCY_START_BALANCE_PROPERTY_NAME);
+        counterCurrencyBalance = new BigDecimal(startingBalanceInConfig);
+        LOG.info(() -> "Counter currency balance at simulation start in BigDecimal format: " + counterCurrencyBalance);
     }
 
     @Override
@@ -133,8 +146,8 @@ public class TA4JRecordingAdapter extends AbstractExchangeAdapter implements Exc
     @Override
     public BalanceInfo getBalanceInfo() throws ExchangeNetworkException, TradingApiException {
         HashMap<String, BigDecimal> availableBalances = new HashMap<>();
-        availableBalances.put(baseCurrency, baseCurrencyBalance);
-        availableBalances.put(counterCurrency, counterCurrencyBalance);
+        availableBalances.put(simulatedBaseCurrency, baseCurrencyBalance);
+        availableBalances.put(simulatedCounterCurrency, counterCurrencyBalance);
         return new BalanceInfoImpl(availableBalances, new HashMap<>());
     }
 

--- a/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/TA4JRecordingAdapter.java
+++ b/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/TA4JRecordingAdapter.java
@@ -34,7 +34,6 @@ public class TA4JRecordingAdapter extends AbstractExchangeAdapter implements Exc
 
     private BigDecimal buyFeePercentage;
     private BigDecimal sellFeePercentage;
-    private BigDecimal sellLimitDistancePercentage;
     private String tradingSeriesTradingPath;
     private String simulatedCounterCurrency;
     private String simulatedBaseCurrency;
@@ -77,11 +76,6 @@ public class TA4JRecordingAdapter extends AbstractExchangeAdapter implements Exc
         sellFeePercentage =
                 new BigDecimal(sellFeeInConfig).divide(new BigDecimal("100"), 8, RoundingMode.HALF_UP);
         LOG.info(() -> "Sell fee % in BigDecimal format: " + sellFeePercentage);
-
-        final String sellLimitDistanceInConfig = getOtherConfigItem(otherConfig, "sell-stop-limit-percentage-distance");
-        sellLimitDistancePercentage =
-                new BigDecimal(sellLimitDistanceInConfig).divide(new BigDecimal("100"), 8, RoundingMode.HALF_UP);
-        LOG.info(() -> "Sell (stop-limit order) limit distance % in BigDecimal format: " + sellLimitDistancePercentage);
 
         tradingSeriesTradingPath = getOtherConfigItem(otherConfig, PATH_TO_SERIES_JSON_PROPERTY_NAME);
         LOG.info(() -> "path to load series json from for recording:" + tradingSeriesTradingPath);

--- a/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/ta4jhelper/BuyAndSellSignalsToChart.java
+++ b/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/ta4jhelper/BuyAndSellSignalsToChart.java
@@ -1,0 +1,137 @@
+package com.gazbert.bxbot.exchanges.ta4jhelper;
+
+import org.jfree.chart.ChartFactory;
+import org.jfree.chart.ChartPanel;
+import org.jfree.chart.JFreeChart;
+import org.jfree.chart.axis.DateAxis;
+import org.jfree.chart.plot.Marker;
+import org.jfree.chart.plot.ValueMarker;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.data.time.Second;
+import org.jfree.data.time.TimeSeries;
+import org.jfree.data.time.TimeSeriesCollection;
+import org.jfree.ui.ApplicationFrame;
+import org.jfree.ui.RefineryUtilities;
+import org.ta4j.core.*;
+import org.ta4j.core.indicators.helpers.ClosePriceIndicator;
+import org.ta4j.core.indicators.helpers.HighPriceIndicator;
+import org.ta4j.core.indicators.helpers.LowPriceIndicator;
+import org.ta4j.core.num.Num;
+
+import java.awt.*;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * This class builds a graphical chart showing the buy/sell signals of a
+ * strategy.
+ */
+public class BuyAndSellSignalsToChart {
+
+    /**
+     * Builds a JFreeChart time series from a Ta4j bar series and an indicator.
+     *
+     * @param barSeries the ta4j bar series
+     * @param indicator the indicator
+     * @param name      the name of the chart time series
+     * @return the JFreeChart time series
+     */
+    private static TimeSeries buildChartTimeSeries(BarSeries barSeries, Indicator<Num> indicator,
+                                                   String name) {
+        TimeSeries chartTimeSeries = new TimeSeries(name);
+        for (int i = 0; i < barSeries.getBarCount(); i++) {
+            Bar bar = barSeries.getBar(i);
+            chartTimeSeries.add(new Second(Date.from(bar.getEndTime().toInstant())),
+                    indicator.getValue(i).doubleValue());
+        }
+        return chartTimeSeries;
+    }
+
+    /**
+     * Runs a strategy over a bar series and adds the value markers corresponding to
+     * buy/sell signals to the plot.
+     *
+     * @param series   the bar series
+     * @param strategy the trading strategy
+     * @param plot     the plot
+     */
+    private static void addBuySellSignals(BarSeries series, Strategy strategy, XYPlot plot) {
+        // Running the strategy
+        BarSeriesManager seriesManager = new BarSeriesManager(series);
+        List<Trade> positions = seriesManager.run(strategy).getTrades();
+        // Adding markers to plot
+        for (Trade position : positions) {
+            // Buy signal
+            double buySignalBarTime = new Second(
+                    Date.from(series.getBar(position.getEntry().getIndex()).getEndTime().toInstant()))
+                            .getFirstMillisecond();
+            Marker buyMarker = new ValueMarker(buySignalBarTime);
+            buyMarker.setPaint(Color.GREEN);
+            buyMarker.setLabel("B");
+            plot.addDomainMarker(buyMarker);
+            // Sell signal
+            double sellSignalBarTime = new Second(
+                    Date.from(series.getBar(position.getExit().getIndex()).getEndTime().toInstant()))
+                            .getFirstMillisecond();
+            Marker sellMarker = new ValueMarker(sellSignalBarTime);
+            sellMarker.setPaint(Color.RED);
+            sellMarker.setLabel("S");
+            plot.addDomainMarker(sellMarker);
+        }
+    }
+
+    /**
+     * Displays a chart in a frame.
+     *
+     * @param chart the chart to be displayed
+     */
+    private static void displayChart(JFreeChart chart) {
+        // Chart panel
+        ChartPanel panel = new ChartPanel(chart);
+        panel.setFillZoomRectangle(true);
+        panel.setMouseWheelEnabled(true);
+        panel.setPreferredSize(new Dimension(1024, 400));
+        // Application frame
+        ApplicationFrame frame = new ApplicationFrame("Ta4j example - Buy and sell signals to chart");
+        frame.setContentPane(panel);
+        frame.pack();
+        RefineryUtilities.centerFrameOnScreen(frame);
+        frame.setVisible(true);
+    }
+
+    public static void printSeries(BarSeries series, Strategy strategy) {
+        System.setProperty("java.awt.headless", "false");
+        /*
+         * Building chart datasets
+         */
+        TimeSeriesCollection dataset = new TimeSeriesCollection();
+        dataset.addSeries(buildChartTimeSeries(series, new ClosePriceIndicator(series), "Close"));
+        dataset.addSeries(buildChartTimeSeries(series, new HighPriceIndicator(series), "Ask"));
+        dataset.addSeries(buildChartTimeSeries(series, new LowPriceIndicator(series), "Bid"));
+
+        /*
+         * Creating the chart
+         */
+        JFreeChart chart = ChartFactory.createTimeSeriesChart(strategy.getName(), // title
+                "Date", // x-axis label
+                "Price", // y-axis label
+                dataset, // data
+                true, // create legend?
+                true, // generate tooltips?
+                false // generate URLs?
+        );
+        XYPlot plot = (XYPlot) chart.getPlot();
+        DateAxis axis = (DateAxis) plot.getDomainAxis();
+        axis.setDateFormatOverride(new SimpleDateFormat("MM-dd HH:mm:ss"));
+
+        /*
+         * Running the strategy and adding the buy and sell signals to plot
+         */
+        addBuySellSignals(series, strategy, plot);
+        /*
+         * Displaying the chart
+         */
+        displayChart(chart);
+    }
+}

--- a/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/ta4jhelper/GsonBarData.java
+++ b/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/ta4jhelper/GsonBarData.java
@@ -1,0 +1,39 @@
+package com.gazbert.bxbot.exchanges.ta4jhelper;
+
+import org.ta4j.core.Bar;
+import org.ta4j.core.BaseBarSeries;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class GsonBarData {
+    private long endTime;
+    private Number openPrice;
+    private Number highPrice;
+    private Number lowPrice;
+    private Number closePrice;
+    private Number volume;
+    private Number amount;
+
+    public static GsonBarData from(Bar bar) {
+        GsonBarData result = new GsonBarData();
+        result.endTime = bar.getEndTime().toInstant().toEpochMilli();
+        result.openPrice = bar.getOpenPrice().getDelegate();
+        result.highPrice = bar.getHighPrice().getDelegate();
+        result.lowPrice = bar.getLowPrice().getDelegate();
+        result.closePrice = bar.getClosePrice().getDelegate();
+        result.volume = bar.getVolume().getDelegate();
+        result.amount = bar.getAmount().getDelegate();
+        return result;
+    }
+
+    public void addTo(BaseBarSeries barSeries) {
+        Instant endTimeInstant = Instant.ofEpochMilli(endTime);
+        ZonedDateTime endBarTime = ZonedDateTime.ofInstant(endTimeInstant, ZoneId.systemDefault());
+        Number volumeToAdd = volume == null ? BigDecimal.ZERO : volume;
+        Number amountToAdd = amount == null ? BigDecimal.ZERO : amount;
+        barSeries.addBar(endBarTime, openPrice, highPrice, lowPrice, closePrice, volumeToAdd, amountToAdd);
+    }
+}

--- a/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/ta4jhelper/GsonBarSeries.java
+++ b/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/ta4jhelper/GsonBarSeries.java
@@ -1,0 +1,34 @@
+package com.gazbert.bxbot.exchanges.ta4jhelper;
+
+import org.ta4j.core.Bar;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseBarSeries;
+import org.ta4j.core.BaseBarSeriesBuilder;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class GsonBarSeries {
+
+    private String name;
+    private List<GsonBarData> ohlc = new LinkedList<>();
+
+    public static GsonBarSeries from(BarSeries series) {
+        GsonBarSeries result = new GsonBarSeries();
+        result.name = series.getName();
+        List<Bar> barData = series.getBarData();
+        for (Bar bar : barData) {
+            GsonBarData exportableBarData = GsonBarData.from(bar);
+            result.ohlc.add(exportableBarData);
+        }
+        return result;
+    }
+
+    public BarSeries toBarSeries() {
+        BaseBarSeries result = new BaseBarSeriesBuilder().withName(this.name).build();
+        for (GsonBarData data : ohlc) {
+            data.addTo(result);
+        }
+        return result;
+    }
+}

--- a/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/ta4jhelper/JsonBarsSerializer.java
+++ b/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/ta4jhelper/JsonBarsSerializer.java
@@ -1,0 +1,70 @@
+package com.gazbert.bxbot.exchanges.ta4jhelper;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.ta4j.core.BarSeries;
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class JsonBarsSerializer {
+
+    private static final Logger LOG = Logger.getLogger(JsonBarsSerializer.class.getName());
+    private static Map<String, GsonBarSeries> cachedSeries = new HashMap<>();
+
+    public static void persistSeries(BarSeries series, String filename) {
+        GsonBarSeries exportableSeries = GsonBarSeries.from(series);
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        FileWriter writer = null;
+        try {
+            writer = new FileWriter(filename);
+            gson.toJson(exportableSeries, writer);
+            LOG.info("Bar series '" + series.getName() + "' successfully saved to '" + filename + "'");
+        } catch (IOException e) {
+            e.printStackTrace();
+            LOG.log(Level.SEVERE, "Unable to store bars in JSON", e);
+        } finally {
+            if (writer != null) {
+                try {
+                    writer.flush();
+                    writer.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    public static BarSeries loadSeries(String filename) {
+        if (cachedSeries.containsKey(filename)) {
+            return cachedSeries.get(filename).toBarSeries();
+        }
+        Gson gson = new Gson();
+        FileReader reader = null;
+        BarSeries result = null;
+        try {
+            reader = new FileReader(filename);
+            GsonBarSeries loadedSeries = gson.fromJson(reader, GsonBarSeries.class);
+            cachedSeries.put(filename, loadedSeries);
+            result = loadedSeries.toBarSeries();
+            LOG.info("Bar series '" + result.getName() + "' successfully loaded. #Entries: " + result.getBarCount());
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+            LOG.log(Level.SEVERE, "Unable to load bars from JSON", e);
+        } finally {
+            try {
+                if (reader != null)
+                    reader.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        return result;
+    }
+}

--- a/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/ta4jhelper/TA4JRecordingRule.java
+++ b/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/ta4jhelper/TA4JRecordingRule.java
@@ -1,0 +1,28 @@
+package com.gazbert.bxbot.exchanges.ta4jhelper;
+
+import com.gazbert.bxbot.trading.api.TradingApiException;
+import org.ta4j.core.TradingRecord;
+import org.ta4j.core.trading.rules.AbstractRule;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class TA4JRecordingRule extends AbstractRule {
+    private Set<Integer> recordedIndeces = new HashSet<>();
+
+    public void addTrigger(int index) throws TradingApiException {
+        if(recordedIndeces.contains(index)) {
+            throw new TradingApiException("Recorded two trades at the same time.");
+        }
+        recordedIndeces.add(index);
+    }
+
+
+
+    @Override
+    public boolean isSatisfied(int index, TradingRecord tradingRecord) {
+        final boolean satisfied = recordedIndeces.contains(index);
+        traceIsSatisfied(index, satisfied);
+        return satisfied;
+    }
+}

--- a/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/ta4jhelper/Ta4jOptimalTradingStrategy.java
+++ b/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/ta4jhelper/Ta4jOptimalTradingStrategy.java
@@ -1,0 +1,78 @@
+package com.gazbert.bxbot.exchanges.ta4jhelper;
+
+import com.gazbert.bxbot.trading.api.TradingApiException;
+import org.ta4j.core.Bar;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.BaseStrategy;
+import org.ta4j.core.num.Num;
+
+import java.math.BigDecimal;
+
+public class Ta4jOptimalTradingStrategy extends BaseStrategy {
+    private static final TA4JRecordingRule buyRule = new TA4JRecordingRule();
+    private static final TA4JRecordingRule sellRule = new TA4JRecordingRule();
+
+    public Ta4jOptimalTradingStrategy(BarSeries series, BigDecimal buyFee, BigDecimal sellFee) throws TradingApiException {
+        super("Optimal trading rule", buyRule, sellRule);
+        this.calculateOptimalTrades(series, series.numOf(buyFee), series.numOf(sellFee));
+    }
+
+    private void calculateOptimalTrades(BarSeries series, Num buyFee, Num sellFee) throws TradingApiException {
+        int lastSeenMinimumIndex = -1;
+        Num lastSeenMinimum = null;
+        int lastSeenMaximumIndex = -1;
+        Num lastSeenMaximum = null;
+
+        for(int index = series.getBeginIndex(); index <= series.getEndIndex(); index++) {
+            Bar bar = series.getBar(index);
+            Num askPrice = bar.getHighPrice();
+            Num bidPrice = bar.getLowPrice();
+            if (lastSeenMinimum == null) {
+                lastSeenMinimum = askPrice;
+                lastSeenMinimumIndex = index;
+            } else {
+                if (lastSeenMinimum.isGreaterThan(askPrice)) {
+                    createTrade(lastSeenMinimumIndex, lastSeenMinimum, lastSeenMaximumIndex, lastSeenMaximum);
+                    lastSeenMaximum = null;
+                    lastSeenMaximumIndex = -1;
+                    lastSeenMinimum = askPrice;
+                    lastSeenMinimumIndex = index;
+                } else {
+                    Num buyFees = lastSeenMinimum.multipliedBy(buyFee);
+                    Num minimumPlusFees = lastSeenMinimum.plus(buyFees);
+                    Num currentPriceSellFees = bidPrice.multipliedBy(sellFee);
+                    Num currentPriceMinusFees = bidPrice.minus(currentPriceSellFees);
+                    if(lastSeenMaximum == null) {
+                        if(currentPriceMinusFees.isGreaterThan(minimumPlusFees)) {
+                            lastSeenMaximum = bidPrice;
+                            lastSeenMaximumIndex = index;
+                        }
+                    } else {
+                        if(bidPrice.isGreaterThanOrEqual(lastSeenMaximum)) {
+                            lastSeenMaximum = bidPrice;
+                            lastSeenMaximumIndex = index;
+                        } else {
+                            Num lastMaxPriceSellFees = lastSeenMaximum.multipliedBy(sellFee);
+                            Num lastMaxPriceMinusFees = lastSeenMaximum.minus(lastMaxPriceSellFees);
+                            Num currentPricePlusBuyFees = bidPrice.plus(bidPrice.multipliedBy(buyFee));
+                            if (currentPricePlusBuyFees.isLessThan(lastMaxPriceMinusFees)) {
+                                createTrade(lastSeenMinimumIndex, lastSeenMinimum, lastSeenMaximumIndex, lastSeenMaximum);
+                                lastSeenMaximum = null;
+                                lastSeenMaximumIndex = -1;
+                                lastSeenMinimum = askPrice;
+                                lastSeenMinimumIndex = index;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private void createTrade(int lastSeenMinimumIndex, Num lastSeenMinimum, int lastSeenMaximumIndex, Num lastSeenMaximum) throws TradingApiException {
+        if (lastSeenMinimum != null && lastSeenMaximum != null) {
+            buyRule.addTrigger(lastSeenMinimumIndex);
+            sellRule.addTrigger(lastSeenMaximumIndex);
+        }
+    }
+}

--- a/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/ta4jhelper/TradePriceRespectingBacktestExecutor.java
+++ b/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/ta4jhelper/TradePriceRespectingBacktestExecutor.java
@@ -1,0 +1,53 @@
+package com.gazbert.bxbot.exchanges.ta4jhelper;
+
+import org.ta4j.core.*;
+import org.ta4j.core.cost.CostModel;
+import org.ta4j.core.cost.ZeroCostModel;
+import org.ta4j.core.num.Num;
+import org.ta4j.core.tradereport.TradingStatement;
+import org.ta4j.core.tradereport.TradingStatementGenerator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TradePriceRespectingBacktestExecutor {
+
+    private final TradingStatementGenerator tradingStatementGenerator;
+    private final BarSeriesManager seriesManager;
+
+    public TradePriceRespectingBacktestExecutor(BarSeries series, CostModel transactionCostModel) {
+        this(series, new TradingStatementGenerator(), transactionCostModel);
+    }
+
+    public TradePriceRespectingBacktestExecutor(BarSeries series, TradingStatementGenerator tradingStatementGenerator, CostModel transactionCostModel) {
+        this.seriesManager = new BarSeriesManager(series, transactionCostModel, new ZeroCostModel());
+        this.tradingStatementGenerator = tradingStatementGenerator;
+    }
+
+    /**
+     * Execute given strategies and return trading statements
+     *
+     * @param amount - The amount used to open/close the trades
+     */
+    public List<TradingStatement> execute(List<Strategy> strategies, Num amount) {
+        return execute(strategies, amount, Order.OrderType.BUY);
+    }
+
+    /**
+     * Execute given strategies with specified order type to open trades and return
+     * trading statements
+     *
+     * @param amount    - The amount used to open/close the trades
+     * @param orderType the {@link Order.OrderType} used to open the trades
+     */
+    public List<TradingStatement> execute(List<Strategy> strategies, Num amount, Order.OrderType orderType) {
+        final List<TradingStatement> tradingStatements = new ArrayList<>(strategies.size());
+        for (Strategy strategy : strategies) {
+            final TradingRecord tradingRecord = seriesManager.run(strategy, orderType, amount);
+            final TradingStatement tradingStatement = tradingStatementGenerator.generate(strategy, tradingRecord,
+                    seriesManager.getBarSeries());
+            tradingStatements.add(tradingStatement);
+        }
+        return tradingStatements;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,16 @@
         <artifactId>hibernate-validator-annotation-processor</artifactId>
         <version>${hibernate-vaildator.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.ta4j</groupId>
+        <artifactId>ta4j-core</artifactId>
+        <version>0.13</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jfree</groupId>
+        <artifactId>jfreechart</artifactId>
+        <version>1.0.17</version>
+      </dependency>
 
       <!--
       Testing dependencies


### PR DESCRIPTION
Added an adapter which allows to backtest a strategy with ta4j given a recorded ta4j baseseries as json.

Some remarks/limitations:

* The simulation adapter is based on a current "tick", which is increased every time the "getTicker" is called
  * This means especially, that a strategy must call getTicker in its execute phase at all
  * This means especially, that a strategy most not call getTicker multiple times in the same execution phase
* JSON handling
   * It is assumed, that the recorded base series (and stored as json) added every ticker update from the real market in an own "bar"
   * Furthermore it is assumed, that the getHigh of each bar contains the ask-price
   * Furthermore it is assumed, that the getLow of each bar contains the bid-price
   * An example on how to capture a barseries and how to store it to json will be added in an example strategy
* ta4j can't differentiate costs for sell and buy orders, thats why only one fee can be configured
* one can configure if the recorded and backtested orders should be printed to a graph. This needs a display (x11) to be available for the java runtime
* For comparison reasons, a rudimentary "optimal order" calculation is added
* As the backend cannot be stopped normaly (as far as I saw), the ta4j-simulation adapter throws a tradingApiException as soon as the end of the available barseries is reached

