### PR TITLE
Feature/accquire order min

### DIFF
--- a/bxbot-exchange-api/src/main/java/com/gazbert/bxbot/exchange/api/PairPrecisionConfig.java
+++ b/bxbot-exchange-api/src/main/java/com/gazbert/bxbot/exchange/api/PairPrecisionConfig.java
@@ -56,7 +56,7 @@ public interface PairPrecisionConfig {
 
   /**
    * Gets the minimal amount  of order volume for this pair. The default value if no pair is found
-   * will be -1.
+   * will be null.
    *
    * @param pair the coin pair.
    * @return the minimum amount of order volume.

--- a/bxbot-exchange-api/src/main/java/com/gazbert/bxbot/exchange/api/PairPrecisionConfig.java
+++ b/bxbot-exchange-api/src/main/java/com/gazbert/bxbot/exchange/api/PairPrecisionConfig.java
@@ -23,6 +23,8 @@
 
 package com.gazbert.bxbot.exchange.api;
 
+import java.math.BigDecimal;
+
 /**
  * <p>Some Exchange Adapters will need custom precision configs when placing orders.</p>
  *
@@ -35,7 +37,7 @@ package com.gazbert.bxbot.exchange.api;
 public interface PairPrecisionConfig {
 
   /**
-   * Gets the number of decimal places for price precision. The default value id no pair is found
+   * Gets the number of decimal places for price precision. The default value if no pair is found
    * will be -1.
    *
    * @param pair the coin pair.
@@ -44,12 +46,21 @@ public interface PairPrecisionConfig {
   int getPricePrecision(String pair);
 
   /**
-   * Gets the number of decimal places for volume precision. The default value id no pair is found
+   * Gets the number of decimal places for volume precision. The default value if no pair is found
    * will be -1.
    *
    * @param pair the coin pair.
    * @return the number of decimal places for volume.
    */
   int getVolumePrecision(String pair);
+
+  /**
+   * Gets the minimal amount  of order volume for this pair. The default value if no pair is found
+   * will be -1.
+   *
+   * @param pair the coin pair.
+   * @return the minimum amount of order volume.
+   */
+  BigDecimal getMinimalOrderVolume(String pair);
 
 }

--- a/bxbot-exchange-api/src/main/java/com/gazbert/bxbot/exchange/api/PairPrecisionConfig.java
+++ b/bxbot-exchange-api/src/main/java/com/gazbert/bxbot/exchange/api/PairPrecisionConfig.java
@@ -26,10 +26,10 @@ package com.gazbert.bxbot.exchange.api;
 import java.math.BigDecimal;
 
 /**
- * <p>Some Exchange Adapters will need custom precision configs when placing orders.</p>
+ * Some Exchange Adapters will need custom precision configs when placing orders.
  *
- * <p>This interface allows us to have a uniform way to fetch this precision for the
- * various Exchange houses.</p>
+ * <p>This interface allows us to have a uniform way to fetch this precision for the various
+ * Exchange houses.
  *
  * @author maiph
  * @since 1.2
@@ -55,12 +55,11 @@ public interface PairPrecisionConfig {
   int getVolumePrecision(String pair);
 
   /**
-   * Gets the minimal amount  of order volume for this pair. The default value if no pair is found
+   * Gets the minimal amount of order volume for this pair. The default value if no pair is found
    * will be null.
    *
    * @param pair the coin pair.
    * @return the minimum amount of order volume.
    */
   BigDecimal getMinimalOrderVolume(String pair);
-
 }

--- a/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/KrakenExchangeAdapter.java
+++ b/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/KrakenExchangeAdapter.java
@@ -534,6 +534,11 @@ public final class KrakenExchangeAdapter extends AbstractExchangeAdapter
   }
 
   @Override
+  public BigDecimal getMinimumOrderVolume(String marketId) throws TradingApiException, ExchangeNetworkException {
+    return pairPrecisionConfig.getMinimalOrderVolume(marketId);
+  }
+
+  @Override
   public String getImplName() {
     return "Kraken API v1";
   }

--- a/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/KrakenExchangeAdapter.java
+++ b/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/KrakenExchangeAdapter.java
@@ -662,6 +662,7 @@ public final class KrakenExchangeAdapter extends AbstractExchangeAdapter
       Gson gson = new Gson();
       Map<String, Integer> prices = new HashMap<>();
       Map<String, Integer> volumes = new HashMap<>();
+      Map<String, BigDecimal> orderMins = new HashMap<>();
 
       for (Entry<String, Object> entry : this.entrySet()) {
         JsonElement jsonElement = gson.toJsonTree(entry);
@@ -670,12 +671,15 @@ public final class KrakenExchangeAdapter extends AbstractExchangeAdapter
         String name = jsonObject.get("altname").getAsString();
         int price = jsonObject.get("pair_decimals").getAsInt();
         int volume = jsonObject.get("lot_decimals").getAsInt();
+        BigDecimal orderMin = jsonObject.get("ordermin").getAsBigDecimal();
+
 
         prices.put(name, price);
         volumes.put(name, volume);
+        orderMins.put(name, orderMin);
       }
 
-      return new PairPrecisionConfigImpl(prices, volumes);
+      return new PairPrecisionConfigImpl(prices, volumes, orderMins);
     }
   }
 

--- a/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/KrakenExchangeAdapter.java
+++ b/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/KrakenExchangeAdapter.java
@@ -671,12 +671,14 @@ public final class KrakenExchangeAdapter extends AbstractExchangeAdapter
         String name = jsonObject.get("altname").getAsString();
         int price = jsonObject.get("pair_decimals").getAsInt();
         int volume = jsonObject.get("lot_decimals").getAsInt();
-        BigDecimal orderMin = jsonObject.get("ordermin").getAsBigDecimal();
+        if (jsonObject.has("ordermin")) {
+          BigDecimal orderMin = jsonObject.get("ordermin").getAsBigDecimal();
+          orderMins.put(name, orderMin);
+        }
 
 
         prices.put(name, price);
         volumes.put(name, volume);
-        orderMins.put(name, orderMin);
       }
 
       return new PairPrecisionConfigImpl(prices, volumes, orderMins);

--- a/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/KrakenExchangeAdapter.java
+++ b/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/KrakenExchangeAdapter.java
@@ -534,7 +534,7 @@ public final class KrakenExchangeAdapter extends AbstractExchangeAdapter
   }
 
   @Override
-  public BigDecimal getMinimumOrderVolume(String marketId) throws TradingApiException, ExchangeNetworkException {
+  public BigDecimal getMinimumOrderVolume(String marketId) {
     return pairPrecisionConfig.getMinimalOrderVolume(marketId);
   }
 

--- a/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/config/PairPrecisionConfigImpl.java
+++ b/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/config/PairPrecisionConfigImpl.java
@@ -57,6 +57,6 @@ public class PairPrecisionConfigImpl implements PairPrecisionConfig {
 
   @Override
   public BigDecimal getMinimalOrderVolume(String pair) {
-    return orderMins.getOrDefault(pair, new BigDecimal("-1"));
+    return orderMins.getOrDefault(pair, null);
   }
 }

--- a/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/config/PairPrecisionConfigImpl.java
+++ b/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/config/PairPrecisionConfigImpl.java
@@ -24,7 +24,6 @@
 package com.gazbert.bxbot.exchanges.config;
 
 import com.gazbert.bxbot.exchange.api.PairPrecisionConfig;
-
 import java.math.BigDecimal;
 import java.util.Map;
 
@@ -39,7 +38,13 @@ public class PairPrecisionConfigImpl implements PairPrecisionConfig {
   private final Map<String, Integer> volumes;
   private final Map<String, BigDecimal> orderMins;
 
-  public PairPrecisionConfigImpl(Map<String, Integer> prices, Map<String, Integer> volumes, Map<String, BigDecimal> orderMins) {
+  /**
+   * Default implementation of {@link PairPrecisionConfig} backed by {@link Map}s.
+   */
+  public PairPrecisionConfigImpl(
+      Map<String, Integer> prices,
+      Map<String, Integer> volumes,
+      Map<String, BigDecimal> orderMins) {
     this.prices = prices;
     this.volumes = volumes;
     this.orderMins = orderMins;

--- a/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/config/PairPrecisionConfigImpl.java
+++ b/bxbot-exchanges/src/main/java/com/gazbert/bxbot/exchanges/config/PairPrecisionConfigImpl.java
@@ -24,6 +24,8 @@
 package com.gazbert.bxbot.exchanges.config;
 
 import com.gazbert.bxbot.exchange.api.PairPrecisionConfig;
+
+import java.math.BigDecimal;
 import java.util.Map;
 
 /**
@@ -35,10 +37,12 @@ public class PairPrecisionConfigImpl implements PairPrecisionConfig {
 
   private final Map<String, Integer> prices;
   private final Map<String, Integer> volumes;
+  private final Map<String, BigDecimal> orderMins;
 
-  public PairPrecisionConfigImpl(Map<String, Integer> prices, Map<String, Integer> volumes) {
+  public PairPrecisionConfigImpl(Map<String, Integer> prices, Map<String, Integer> volumes, Map<String, BigDecimal> orderMins) {
     this.prices = prices;
     this.volumes = volumes;
+    this.orderMins = orderMins;
   }
 
   @Override
@@ -49,5 +53,10 @@ public class PairPrecisionConfigImpl implements PairPrecisionConfig {
   @Override
   public int getVolumePrecision(String pair) {
     return volumes.getOrDefault(pair, -1);
+  }
+
+  @Override
+  public BigDecimal getMinimalOrderVolume(String pair) {
+    return orderMins.getOrDefault(pair, new BigDecimal("-1"));
   }
 }

--- a/bxbot-exchanges/src/test/java/com/gazbert/bxbot/exchanges/TestKrakenExchangeAdapter.java
+++ b/bxbot-exchanges/src/test/java/com/gazbert/bxbot/exchanges/TestKrakenExchangeAdapter.java
@@ -1105,6 +1105,32 @@ public class TestKrakenExchangeAdapter extends AbstractExchangeAdapterTest {
     PowerMock.verifyAll();
   }
 
+  @Test
+  public void testGettingMinOrderVolumeIfAvailable() throws Exception {
+    PowerMock.replayAll();
+
+    final ExchangeAdapter exchangeAdapter = new KrakenExchangeAdapter();
+    exchangeAdapter.init(exchangeConfig);
+
+    final BigDecimal minimumOrderVolume = exchangeAdapter.getMinimumOrderVolume("XBTUSD");
+    assertEquals(0, minimumOrderVolume.compareTo(new BigDecimal("0.0001")));
+
+    PowerMock.verifyAll();
+  }
+
+  @Test
+  public void testGettingMinOrderVolumeIfNotAvailable() throws Exception {
+    PowerMock.replayAll();
+
+    final ExchangeAdapter exchangeAdapter = new KrakenExchangeAdapter();
+    exchangeAdapter.init(exchangeConfig);
+
+    final BigDecimal minimumOrderVolume = exchangeAdapter.getMinimumOrderVolume("XBTGBP.d");
+    assertNull(minimumOrderVolume);
+
+    PowerMock.verifyAll();
+  }
+
   // --------------------------------------------------------------------------
   //  Initialisation tests
   // --------------------------------------------------------------------------

--- a/bxbot-trading-api/src/main/java/com/gazbert/bxbot/trading/api/TradingApi.java
+++ b/bxbot-trading-api/src/main/java/com/gazbert/bxbot/trading/api/TradingApi.java
@@ -51,7 +51,7 @@ public interface TradingApi {
    * @since 1.0
    */
   default String getVersion() {
-    return "1.1";
+    return "1.2";
   }
 
   /**
@@ -214,6 +214,36 @@ public interface TradingApi {
    */
   BigDecimal getPercentageOfSellOrderTakenForExchangeFee(String marketId)
       throws TradingApiException, ExchangeNetworkException;
+
+  /**
+   * Returns the minimum order volume for a given market id. The returned value is the order volume
+   * that a SELL or BUY order must at least have as amount of the base currency for the given
+   * currency pair.
+   *
+   * <p>Not all exchanges provide this information or not fully provide it (only for some
+   *  currency pairs)- you'll need to check the relevant Exchange Adapter code/Javadoc and online
+   *  Exchange API documentation.
+   *
+   * <p>If the exchange does not provide the information at all or for the current market id,
+   * a null value is returned.
+   *
+   * @param marketId the id of the market.
+   * @return the minimum order volume in base currency that is needed to place a Order as a {@link
+   *     BigDecimal}.
+   * @throws ExchangeNetworkException if a network error occurred trying to connect to the exchange.
+   *     This is implementation specific for each Exchange Adapter - see the documentation for the
+   *     adapter you are using. You could retry the API call, or exit from your Trading Strategy and
+   *     let the Trading Engine execute your Trading Strategy at the next trade cycle.
+   * @throws TradingApiException if the API call failed for any reason other than a network error.
+   *     This means something bad as happened; you would probably want to wrap this exception in a
+   *     StrategyException and let the Trading Engine shutdown the bot immediately to prevent
+   *     unexpected losses.
+   * @since 1.2
+   */
+  default BigDecimal getMinimumOrderVolume(String marketId)
+          throws TradingApiException, ExchangeNetworkException {
+    return null;
+  }
 
   /**
    * Returns the exchange Ticker a given market id.

--- a/bxbot-trading-api/src/test/java/com/gazbert/bxbot/trading/api/TestTradingApi.java
+++ b/bxbot-trading-api/src/test/java/com/gazbert/bxbot/trading/api/TestTradingApi.java
@@ -109,5 +109,10 @@ public class TestTradingApi {
     public BigDecimal getPercentageOfSellOrderTakenForExchangeFee(String marketId) {
       return null;
     }
+
+    @Override
+    public BigDecimal getMinimumOrderVolume(String marketId) throws TradingApiException, ExchangeNetworkException {
+      return null;
+    }
   }
 }

--- a/bxbot-trading-api/src/test/java/com/gazbert/bxbot/trading/api/TestTradingApi.java
+++ b/bxbot-trading-api/src/test/java/com/gazbert/bxbot/trading/api/TestTradingApi.java
@@ -41,7 +41,7 @@ public class TestTradingApi {
   @Test
   public void testGetVersion() {
     final MyApiImpl myApi = new MyApiImpl();
-    assertEquals("1.1", myApi.getVersion());
+    assertEquals("1.2", myApi.getVersion());
   }
 
   @Test
@@ -59,6 +59,13 @@ public class TestTradingApi {
     assertNull(ticker.getVolume());
     assertNull(ticker.getVwap());
     assertNull(ticker.getTimestamp());
+  }
+
+  @Test
+  public void testGetMinOrder() throws Exception {
+    final MyApiImpl myApi = new MyApiImpl();
+    final BigDecimal minimumOrderVolume = myApi.getMinimumOrderVolume("market-123");
+    assertNull(minimumOrderVolume);
   }
 
   /** Test class. */
@@ -107,11 +114,6 @@ public class TestTradingApi {
 
     @Override
     public BigDecimal getPercentageOfSellOrderTakenForExchangeFee(String marketId) {
-      return null;
-    }
-
-    @Override
-    public BigDecimal getMinimumOrderVolume(String marketId) throws TradingApiException, ExchangeNetworkException {
       return null;
     }
   }


### PR DESCRIPTION
* added api method to get minimum order amount for the current market pair.
* Implemented the method for the Kraken exchange, which offers getting the minimum order amount
* Default return value is null, if the minimum order amount is not available or implemented